### PR TITLE
fix(adapter): resolve upstream 400s on tool schemas and malformed call args

### DIFF
--- a/src/adapter/translate.ts
+++ b/src/adapter/translate.ts
@@ -65,13 +65,46 @@ export function stripTrailingModelTurn(contents: AgyContent[]): AgyContent[] {
   return contents
 }
 
-/** Recursively remove `enumDescriptions` from tool schemas (upstream rejects with 400). */
-function stripEnumDescriptions(schema: unknown): unknown {
+/**
+ * The Antigravity backend parses tool `parameters` as a strict protobuf
+ * schema and rejects ANY unknown keyword with 400 (verified empirically:
+ * `$schema`, `propertyNames`, `pattern`, `minLength`, ... each fail in turn).
+ * Denylisting is whack-a-mole, so keep only the keywords the upstream
+ * accepts. Container shapes are handled distinctly: `properties` is a
+ * name->schema map (keys preserved), `items`/`additionalProperties` are
+ * nested schemas, `required`/`enum` are plain arrays.
+ */
+const AGY_SCHEMA_ALLOWLIST = new Set([
+  'type', 'format', 'title', 'description', 'nullable',
+  'items', 'enum', 'default', 'properties', 'required', 'additionalProperties',
+])
+const AGY_SCHEMA_MAP_KEYS = new Set(['properties'])
+const AGY_SCHEMA_NESTED_KEYS = new Set(['items', 'additionalProperties'])
+const AGY_SCHEMA_LIST_KEYS = new Set(['required', 'enum'])
+
+function sanitizeToolSchema(schema: unknown): unknown {
   if (!schema || typeof schema !== 'object') return schema
-  if (Array.isArray(schema)) return schema.map((entry) => stripEnumDescriptions(entry))
+  if (Array.isArray(schema)) return schema.map((entry) => sanitizeToolSchema(entry))
   const result: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
-    if (key !== 'enumDescriptions') result[key] = stripEnumDescriptions(value)
+    if (!AGY_SCHEMA_ALLOWLIST.has(key)) continue
+    if (AGY_SCHEMA_MAP_KEYS.has(key)) {
+      const map: Record<string, unknown> = {}
+      for (const [name, child] of Object.entries(value as Record<string, unknown>)) {
+        map[name] = sanitizeToolSchema(child)
+      }
+      result[key] = map
+      continue
+    }
+    if (AGY_SCHEMA_NESTED_KEYS.has(key)) {
+      result[key] = sanitizeToolSchema(value)
+      continue
+    }
+    if (AGY_SCHEMA_LIST_KEYS.has(key)) {
+      result[key] = value
+      continue
+    }
+    result[key] = value
   }
   return result
 }
@@ -96,11 +129,22 @@ function blockToParts(block: ContentBlock, toolNames: Map<string, string>): AgyP
     case 'reasoning':
       return [{ thought: true, text: block.text }]
     case 'tool-call': {
-      let args: unknown = block.arguments
-      try {
-        args = JSON.parse(block.arguments) as unknown
-      } catch {
-        // raw string args fall through (backend tolerates both)
+      // Upstream parses functionCall.args as google.protobuf.Struct and
+      // rejects a raw string with 400. Guarantee an object: parse the string
+      // form, fall back to {} when it is truncated/malformed (the failure
+      // mode for long multi-turn histories).
+      let args: unknown = {}
+      if (typeof block.arguments === 'object' && block.arguments !== null && !Array.isArray(block.arguments)) {
+        args = block.arguments
+      } else if (typeof block.arguments === 'string') {
+        try {
+          const parsed: unknown = JSON.parse(block.arguments)
+          if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            args = parsed
+          }
+        } catch {
+          // truncated/malformed JSON -> empty object
+        }
       }
       // Antigravity rejects functionCall parts without a thoughtSignature
       // (400). Replay the signature captured for this tool call id on the
@@ -143,7 +187,7 @@ function toolsToDeclarations(tools: ToolSchema[] | undefined): AgyRequestBody['r
     functionDeclarations: tools.map((tool) => ({
       name: tool.name,
       description: tool.description,
-      parameters: stripEnumDescriptions(tool.parameters),
+      parameters: sanitizeToolSchema(tool.parameters),
     })),
   }]
 }

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -95,6 +95,69 @@ describe('translate', () => {
     })
   })
 
+  it('keeps only allowlisted keywords in tool schemas (upstream 400)', () => {
+    const body = toAgyRequestBody(
+      generateOptions({
+        tools: [{
+          name: 't1',
+          description: 'd1',
+          parameters: {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            $id: 't1',
+            type: 'object',
+            title: 'T1',
+            description: 'd1',
+            propertyNames: { pattern: '^[a-z]+$' },
+            properties: {
+              name: { type: 'string', pattern: '^[a-z]+$', minLength: 1, maxLength: 10, enumDescriptions: ['a'] },
+              count: { type: 'integer', minimum: 0, maximum: 100 },
+              tags: { type: 'array', items: { type: 'string', minLength: 1 }, minItems: 1, uniqueItems: true },
+              mode: { type: 'string', enum: ['fast', 'slow'], enumDescriptions: ['f', 's'] },
+            },
+            required: ['name'],
+            additionalProperties: false,
+            minProperties: 1,
+          },
+        }],
+      }),
+      {},
+    )
+    expect(body.request.tools).toEqual([{
+      functionDeclarations: [{
+        name: 't1',
+        description: 'd1',
+        parameters: {
+          type: 'object',
+          title: 'T1',
+          description: 'd1',
+          properties: {
+            name: { type: 'string' },
+            count: { type: 'integer' },
+            tags: { type: 'array', items: { type: 'string' } },
+            mode: { type: 'string', enum: ['fast', 'slow'] },
+          },
+          required: ['name'],
+          additionalProperties: false,
+        },
+      }],
+    }])
+  })
+
+  it('falls back to empty args object when tool-call arguments are malformed', () => {
+    const messages = [
+      { id: 'a', role: 'assistant' as const, content: [
+        { type: 'tool-call' as const, id: 'call-1', name: 'web_search', arguments: '{"localPath":"/home/user/' },
+        { type: 'tool-call' as const, id: 'call-2', name: 'read_file', arguments: { path: '/x' } },
+      ]},
+    ]
+    const body = toAgyRequestBody(generateOptions({ messages }), {})
+    const parts = body.request.contents[0]!.parts
+    expect(parts).toEqual([
+      { thoughtSignature: 'skip_thought_signature_validator', functionCall: { id: 'call-1', name: 'web_search', args: {} } },
+      { thoughtSignature: 'skip_thought_signature_validator', functionCall: { id: 'call-2', name: 'read_file', args: { path: '/x' } } },
+    ])
+  })
+
   it('strips trailing model turns for Claude models only', () => {
     const messages = [
       { id: 'a', role: 'assistant' as const, content: [{ type: 'text' as const, text: 'answer' }] },


### PR DESCRIPTION
## Summary

Two upstream 400 errors on the tool-calling path (both real defects, now pinned by tests):

### #1 Upstream rejects JSON-Schema keywords in tool schemas
`stripEnumDescriptions` was a single-keyword denylist, so DSH tool schemas (TypeBox-generated) leaked `$schema`, `$id`, `propertyNames`, `pattern`, `minLength`, etc. into the request — protojson rejects unknown fields with 400. Whack-a-mole.

Replaced with an **allowlist sanitizer** (`sanitizeToolSchema`) that keeps only the upstream-accepted keyword set and handles container shapes correctly (`properties` is a name→schema map, `items`/`additionalProperties` are nested schemas, `required`/`enum` are plain arrays).

### #2 Malformed tool-call args cause protobuf Struct 400
In long multi-turn histories, a truncated/malformed tool-call argument string failed `JSON.parse`, and the raw string was sent upstream — but `functionCall.args` must be a `google.protobuf.Struct` (object), not a string.

`args` is now guaranteed to be an object: parsed when the string is valid, `{}` fallback when malformed, object form passed through as-is.

## Verification

- `pnpm test`: 100/100 pass (2 new tests: allowlist sanitization, malformed-args fallback)
- `pnpm run typecheck`: clean
- Fix matches the reporter's own end-to-end-verified approach (#1's allowlist set comes from their empirical testing)

Thanks to @zhaoyun-plus for the detailed root-cause analysis and real-account verification.

Fixes #1
Fixes #2