### PR TITLE
feat(pool): OMP-aligned multi-account management (usage-driven selection, refresh skew, health checks, risk controls)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ package-lock.json
 
 # editor/agent tooling
 .serena/
+.rtk/

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ fingerprinting, and both CLI and web management.
   paste-URL mode and a remote paste-credential blob channel.
 - **Two management surfaces**: web and CLI, either one works, core features are
   the same.
-- **Multi-account pool**: encrypted account store, automatic rotation on rate
-  limits, per-account cooldown with tiered backoff, per-account device
+- **Multi-account pool**: encrypted account store, usage-aware account
+  selection (family-scoped quotas, OMP-aligned ranking), automatic rotation on
+  rate limits, per-account cooldown to the real reset time, per-account device
   fingerprints.
 - **Quota dashboard**: only active when DSH Web is running; append `/agy` to
   your dsh web address: login, account management, per-model quota bars, model
@@ -119,8 +120,8 @@ valid until it expires or you revoke it in your Google account security settings
 | Category | Behavior |
 |---|---|
 | `soft_rate_limit` (Retry-After < 3s) | immediate retry on the same account, no cooldown |
-| `rate_limited` | 5-minute cooldown + switch to the next account (same account when single) |
-| `quota_exhausted` ("quota reached", "individual quota", RESOURCE_EXHAUSTED…) | 24-hour cooldown — no further calls to that account for the day |
+| `rate_limited` | cooldown until the server-reported reset time (capped 30min, 5min fallback) + switch to the next account (same account when single) |
+| `quota_exhausted` ("quota reached", "individual quota", RESOURCE_EXHAUSTED…) | cooldown until the server-reported reset time (capped 24h) — no further calls to that account until then |
 | `unknown` | exponential backoff |
 
 401/403 → account revoked (marked for re-authentication). Success resets the failure

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ npm install -g dsh-agy
 dsh-agy login          # interactive OAuth (browser, --headless paste, or --blob)
 dsh-agy status         # list accounts + quota summary
 dsh-agy verify         # refresh + health check
+dsh-agy health         # batch health check (optionally on an interval)
 dsh-agy import <file>  # import agy auth.json or credential blob (--blob)
 dsh-agy logout         # remove account
 ```
@@ -77,6 +78,7 @@ dsh-agy logout         # remove account
 | `dsh-agy import <files...>` | `--blob` — the pasted value is a credential blob<br>`--email <email>` — set the account email (skips userinfo verification)<br>`--overwrite` — replace an existing account with the same email | Import agy auth.json files or credential blobs (multiple files / multi-line paste = batch import) |
 | `dsh-agy export` | `--index <n>` — export one account by index (default: all)<br>`--out <dir>` — write one `dsh-agy-<index>.blob` per account (default: print to stdout, one blob per line) | Export account credentials as paste blobs |
 | `dsh-agy verify` | `--index <n>` — verify one account by index (default: all) | Refresh + health check |
+| `dsh-agy health` | `--index <n...>` — check only these accounts (default: all enabled)<br>`--interval <ms>` — repeat on an interval instead of once | Batch health check (refresh + userinfo), re-enables accounts whose credentials are live again |
 | `dsh-agy logout` | `--index <n>` — account index (default: active)<br>`--email <email>` — account email | Remove an account |
 
 ### Path C: Local Development & Link
@@ -115,6 +117,13 @@ valid until it expires or you revoke it in your Google account security settings
 
 ### Rotation mechanics
 
+Usage-aware selection: when several accounts are available, requests rank them
+by the requested model's backend counter family (`gemini-*` → Google,
+`claude-*` → Anthropic, `gpt-*` → OpenAI): accounts whose quota is about to
+reset with headroom left are used first ("use it or lose it"), near-exhausted
+families are avoided, and exhausted families block the account until the real
+reset time.
+
 429 (Too Many Requests) responses:
 
 | Category | Behavior |
@@ -126,6 +135,15 @@ valid until it expires or you revoke it in your Google account security settings
 
 401/403 → account revoked (marked for re-authentication). Success resets the failure
 counter.
+
+### Risk controls (environment switches)
+
+| Env | Effect |
+|---|---|
+| `DSH_AGY_DISABLE=1` | Kill switch: the plugin registers nothing (provider + `/agy` routes) and the CLI refuses to run. |
+| `DSH_AGY_FINGERPRINT_MODE=stable` | One fixed client identity per account — no per-request header randomization, no fingerprint regeneration (OMP-style fixed-client posture). Default `dynamic` keeps per-request randomization. |
+| `DSH_AGY_HEALTH_INTERVAL_MS=<ms>` | Background batch health probe inside the harness (refresh + userinfo on the configured interval); off by default. |
+| `AGY_CLIENT_ID` / `AGY_CLIENT_SECRET` | BYO OAuth app escape hatch: override the embedded public Antigravity client credentials. |
 
 ### About cache hits: why not 99% like DeepSeek V4?
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,7 +47,8 @@ Dependency direction: `oauth/` and `store/` are leaves (no internal deps); `runt
 | `oauth/blob` | `encode/decode(blob)` | prefix validation, provider binding anti-replay | pure unit |
 | `store/accounts` | `load() / save(acc) / mutate(fn)` | encryption, proper-lockfile, migration chain, dedup, 0600 | **in-memory fake** (second adapter, a legitimate seam) |
 | `runtime/classify` | `classify(error) -> Kind` | 429/403/network-error parsing, Retry-After, resetTime | fixture |
-| `runtime/rotation` | `onFailure(acc, kind) -> Action` | cooldown, tiered backoff, activeIndex switching, fingerprint-regeneration trigger | state-machine unit tests |
+| `runtime/rotation` | `onFailure(acc, kind) -> Action` | cooldown to the server-reported reset time (capped 30min/24h), tiered backoff, activeIndex switching, fingerprint-regeneration trigger | state-machine unit tests |
+| `runtime/quota` | `rank(accounts, model) -> order` | fetchAvailableModels → per-family quota records (google/anthropic/openai), drained/hot-window guards, required-drain ranking (OMP-aligned) | pure unit |
 | `runtime/fingerprint` | `generate() -> Fingerprint` | random platform/arch/SDK pool, history mgmt (<=5), version sync; **data externalized to JSON** | pure unit |
 | `adapter/translate` | `toBody(generateOptions) -> RequestBody` | DSH messages/tools -> Gemini contents[], thinking carried verbatim | fixture (recorded requests) |
 | `adapter/parse` | `fromSSE(line) -> Chunk[]` | SSE line parsing, candidates[] -> StreamChunk, usage/error events | fixture (recorded responses) |
@@ -67,7 +68,7 @@ Dependency direction: `oauth/` and `store/` are leaves (no internal deps); `runt
 | `thinking-recovery.ts` + warmup | Root cause was "strip thinking to dodge signature validation"; we carry reasoning blocks verbatim, so this problem doesn't arise |
 | `cross-model-integration.ts` | DSH history is provider-neutral blocks; the loop owns cross-model continuity; the source was already deleted in the archived repo |
 | gemini-cli header style / dual quota pool | Google no longer supports that client path; a single quota pool simplifies rotation |
-| Model-family split `activeIndexByFamily` | Not needed for the 1-3 account scenario |
+| Model-family split `activeIndexByFamily` | One affinity pin + family-scoped quota ranking (`runtime/quota`) covers the need without per-family active indices |
 | Plugin Config (schemastery) | No user configuration surface |
 
 ## 5. Directory Tree (final shape)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,6 +49,7 @@ Dependency direction: `oauth/` and `store/` are leaves (no internal deps); `runt
 | `runtime/classify` | `classify(error) -> Kind` | 429/403/network-error parsing, Retry-After, resetTime | fixture |
 | `runtime/rotation` | `onFailure(acc, kind) -> Action` | cooldown to the server-reported reset time (capped 30min/24h), tiered backoff, activeIndex switching, fingerprint-regeneration trigger | state-machine unit tests |
 | `runtime/quota` | `rank(accounts, model) -> order` | fetchAvailableModels → per-family quota records (google/anthropic/openai), drained/hot-window guards, required-drain ranking (OMP-aligned) | pure unit |
+| `runtime/risk` | `isDisabled() / fingerprintMode()` | env-gated kill switch + stable-identity mode (BYO client credentials resolve in oauth/constants) | pure unit |
 | `runtime/fingerprint` | `generate() -> Fingerprint` | random platform/arch/SDK pool, history mgmt (<=5), version sync; **data externalized to JSON** | pure unit |
 | `adapter/translate` | `toBody(generateOptions) -> RequestBody` | DSH messages/tools -> Gemini contents[], thinking carried verbatim | fixture (recorded requests) |
 | `adapter/parse` | `fromSSE(line) -> Chunk[]` | SSE line parsing, candidates[] -> StreamChunk, usage/error events | fixture (recorded responses) |
@@ -69,7 +70,7 @@ Dependency direction: `oauth/` and `store/` are leaves (no internal deps); `runt
 | `cross-model-integration.ts` | DSH history is provider-neutral blocks; the loop owns cross-model continuity; the source was already deleted in the archived repo |
 | gemini-cli header style / dual quota pool | Google no longer supports that client path; a single quota pool simplifies rotation |
 | Model-family split `activeIndexByFamily` | One affinity pin + family-scoped quota ranking (`runtime/quota`) covers the need without per-family active indices |
-| Plugin Config (schemastery) | No user configuration surface |
+| Plugin Config (schemastery) | No plugin Config schema — risk controls are plain env switches (`runtime/risk`) instead |
 
 ## 5. Directory Tree (final shape)
 

--- a/docs/ARCHITECTURE_zh.md
+++ b/docs/ARCHITECTURE_zh.md
@@ -48,6 +48,7 @@
 | `runtime/classify` | `classify(error) → Kind` | 429/403/网络错误解析、Retry-After、resetTime | fixture |
 | `runtime/rotation` | `onFailure(acc, kind) → Action` | 冷却到服务端上报的真实 reset 时间（上限 30min/24h）、backoff 分级、activeIndex 切换、指纹再生触发 | 状态机单元测试 |
 | `runtime/quota` | `rank(accounts, model) → order` | fetchAvailableModels → 按模型族（google/anthropic/openai）聚合配额、drained/hot-window 护栏、required-drain 排名（对齐 OMP） | 纯单元 |
+| `runtime/risk` | `isDisabled() / fingerprintMode()` | 环境开关：总开关 + 固定身份模式（自备客户端凭据在 oauth/constants 解析） | 纯单元 |
 | `runtime/fingerprint` | `generate() → Fingerprint` | 随机平台/arch/SDK 池、历史管理（≤5）、版本同步；**数据外置 JSON** | 纯单元 |
 | `adapter/translate` | `toBody(generateOptions) → RequestBody` | DSH messages/tools → Gemini contents[]，thinking 原样携带 | fixture（录制请求） |
 | `adapter/parse` | `fromSSE(line) → Chunk[]` | SSE 行解析、candidates[] → StreamChunk、usage/错误事件 | fixture（录制响应原文） |
@@ -68,7 +69,7 @@
 | `cross-model-integration.ts` | DSH 历史是 provider-neutral 块，loop 负责跨模型连续性；该模块源码在 archived 仓库中已删除 |
 | gemini-cli 头风格/双配额池 | Google 已不支持该客户端路径；单一配额池简化轮换 |
 | 模型族拆分 `activeIndexByFamily` | 单个亲和 pin + 模型族配额排名（`runtime/quota`）已覆盖需求，无需按族维护独立 activeIndex |
-| 插件 Config（schemastery） | 无用户配置面 |
+| 插件 Config（schemastery） | 无插件 Config schema——风险管控走纯环境开关（`runtime/risk`） |
 
 ## 5. 目录树（最终形态）
 

--- a/docs/ARCHITECTURE_zh.md
+++ b/docs/ARCHITECTURE_zh.md
@@ -46,7 +46,8 @@
 | `oauth/blob` | `encode/decode(blob)` | 前缀校验、provider 绑定防重放 | 纯单元 |
 | `store/accounts` | `load() / save(acc) / mutate(fn)` | 加密、proper-lockfile、迁移链、去重、0600 | **in-memory fake**（第二个 adapter，正当的 seam） |
 | `runtime/classify` | `classify(error) → Kind` | 429/403/网络错误解析、Retry-After、resetTime | fixture |
-| `runtime/rotation` | `onFailure(acc, kind) → Action` | 冷却、backoff 分级、activeIndex 切换、指纹再生触发 | 状态机单元测试 |
+| `runtime/rotation` | `onFailure(acc, kind) → Action` | 冷却到服务端上报的真实 reset 时间（上限 30min/24h）、backoff 分级、activeIndex 切换、指纹再生触发 | 状态机单元测试 |
+| `runtime/quota` | `rank(accounts, model) → order` | fetchAvailableModels → 按模型族（google/anthropic/openai）聚合配额、drained/hot-window 护栏、required-drain 排名（对齐 OMP） | 纯单元 |
 | `runtime/fingerprint` | `generate() → Fingerprint` | 随机平台/arch/SDK 池、历史管理（≤5）、版本同步；**数据外置 JSON** | 纯单元 |
 | `adapter/translate` | `toBody(generateOptions) → RequestBody` | DSH messages/tools → Gemini contents[]，thinking 原样携带 | fixture（录制请求） |
 | `adapter/parse` | `fromSSE(line) → Chunk[]` | SSE 行解析、candidates[] → StreamChunk、usage/错误事件 | fixture（录制响应原文） |
@@ -66,7 +67,7 @@
 | `thinking-recovery.ts` + warmup | 根源是"剥离 thinking 规避签名校验"；我们原样携带 reasoning 块，无此问题 |
 | `cross-model-integration.ts` | DSH 历史是 provider-neutral 块，loop 负责跨模型连续性；该模块源码在 archived 仓库中已删除 |
 | gemini-cli 头风格/双配额池 | Google 已不支持该客户端路径；单一配额池简化轮换 |
-| 模型族拆分 `activeIndexByFamily` | 1–3 账号场景用不到 |
+| 模型族拆分 `activeIndexByFamily` | 单个亲和 pin + 模型族配额排名（`runtime/quota`）已覆盖需求，无需按族维护独立 activeIndex |
 | 插件 Config（schemastery） | 无用户配置面 |
 
 ## 5. 目录树（最终形态）

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -70,6 +70,7 @@ dsh-agy logout         # 删除账号
 | `dsh-agy import <文件...>` | `--blob` — 输入是凭据 blob<br>`--email <email>` — 指定邮箱（跳过 userinfo 校验）<br>`--overwrite` — 覆盖同邮箱的已有账号 | 导入 agy auth.json 文件或凭据 blob（多文件 / 多行粘贴 = 批量导入） |
 | `dsh-agy export` | `--index <n>` — 只导出指定账号（默认全部）<br>`--out <dir>` — 每账号写一个 `dsh-agy-<index>.blob` 文件（默认输出到 stdout，每行一个 blob） | 将账号凭据导出为粘贴 blob |
 | `dsh-agy verify` | `--index <n>` — 只验证指定账号（默认全部） | refresh + 健康检查 |
+| `dsh-agy health` | `--index <n...>` — 只检查指定账号（默认全部启用账号）<br>`--interval <ms>` — 按间隔重复检查 | 批量健康检查（refresh + userinfo），凭据恢复有效的账号自动重新启用 |
 | `dsh-agy logout` | `--index <n>` — 账号索引（默认当前 active）<br>`--email <email>` — 账号邮箱 | 删除账号 |
 
 ### 路径 C：本地源码开发与调试（Link 模式）
@@ -108,6 +109,11 @@ rm -f ~/.dsh/agy-fingerprint-data.json   # 仅当创建过覆盖文件
 
 ### 轮换机制
 
+用量感知选号：多账号时，按请求模型对应的后端计数器族（`gemini-*` → Google、
+`claude-*` → Anthropic、`gpt-*` → OpenAI）排序——即将到期且仍有额度的账号优先
+使用（"不用白不用"），接近耗尽的族会被避开，完全耗尽的族会把账号阻断到真实
+reset 时间。
+
 429 (Too Many Requests)响应：
 
 | 分类 | 行为 |
@@ -118,6 +124,15 @@ rm -f ~/.dsh/agy-fingerprint-data.json   # 仅当创建过覆盖文件
 | `unknown` | 指数退避 |
 
 401/403 → 账号吊销（标记需重新认证）。成功重置失败计数。
+
+### 风险管控（环境开关）
+
+| 环境变量 | 作用 |
+|---|---|
+| `DSH_AGY_DISABLE=1` | 总开关：插件不注册任何东西（provider + `/agy` 路由），CLI 拒绝运行。 |
+| `DSH_AGY_FINGERPRINT_MODE=stable` | 每账号固定一个客户端身份——不做逐请求随机头、不再生指纹（OMP 式固定客户端姿态）。默认 `dynamic` 保持逐请求随机。 |
+| `DSH_AGY_HEALTH_INTERVAL_MS=<ms>` | harness 内后台批量健康探测（按间隔 refresh + userinfo）；默认关闭。 |
+| `AGY_CLIENT_ID` / `AGY_CLIENT_SECRET` | 自备 OAuth App 逃生通道：覆盖内置的公开 Antigravity 客户端凭据。 |
 
 
 ### 关于缓存命中：为什么达不到 DeepSeek V4 的 99%？

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -13,7 +13,7 @@ OAuth 认证、多账号池 + 自动 429 轮换、设备指纹伪装，以及 CL
 
 - **OAuth 登录**: 通过浏览器 OAuth 回调一键登录，支持 headless 粘贴 URL 模式与远程粘贴凭据 blob 通道。
 - **双管理入口**: web 和 cli 任选其一，核心功能一致。
-- **多账号池**: 加密账号存储、限流自动轮换、分级退避冷却、每账号设备指纹。
+- **多账号池**: 加密账号存储、用量感知选号（模型族配额 + OMP 对齐排名）、限流自动轮换、冷却到真实 reset 时间、每账号设备指纹。
 - **配额仪表盘**: 仅在 DSH Web 启动时有效，在你的 dsh web 地址后添加 `/agy` 访问：登录、账号管理、每模型配额条、模型测试、
   凭据导出/导入、指纹管理。
 - **CLI**: `dsh-agy login|status|import|verify|logout`，独立于 harness 运行。
@@ -113,8 +113,8 @@ rm -f ~/.dsh/agy-fingerprint-data.json   # 仅当创建过覆盖文件
 | 分类 | 行为 |
 |---|---|
 | `soft_rate_limit`（Retry-After < 3s） | 同账号立即重试，不冷却 |
-| `rate_limited` | 5 分钟冷却 + 切换到下一账号（单账号时冷却后重试同号） |
-| `quota_exhausted`（"quota reached"/"individual quota"/RESOURCE_EXHAUSTED…） | 24 小时冷却——当天不再尝试调用该账号 |
+| `rate_limited` | 冷却到服务端上报的 reset 时间（上限 30 分钟，无上报时 5 分钟）+ 切换到下一账号（单账号时冷却后重试同号） |
+| `quota_exhausted`（"quota reached"/"individual quota"/RESOURCE_EXHAUSTED…） | 冷却到服务端上报的 reset 时间（上限 24 小时）——到点前不再尝试调用该账号 |
 | `unknown` | 指数退避 |
 
 401/403 → 账号吊销（标记需重新认证）。成功重置失败计数。

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -20,7 +20,8 @@ import type {
   StreamChunk,
   ToolSchema,
 } from '@deepseek-ai/dsh-llm'
-import type { FailureKind, ManagedAccount, OAuthAuthDetails } from '../types.ts'
+import { AgyAuthError, AgyPoolBlockedError } from '../types.ts'
+import type { AgyAccountSession, FailureKind, ManagedAccount, OAuthAuthDetails } from '../types.ts'
 import type { RateLimitCategory } from '../runtime/classify.ts'
 import { fetchAgyFirstOk } from '../oauth/constants.ts'
 import { classifyFetchError, classifyHttpError } from '../runtime/classify.ts'
@@ -28,19 +29,9 @@ import { deriveAntigravitySessionId, generateAntigravityRequestId } from '../run
 import { setThoughtSignature } from '../runtime/signature-cache.ts'
 import { toAgyRequestBody } from './translate.ts'
 import { parseAgySse } from './parse.ts'
-import { AGY_PROVIDER, listAgyModels, resolveAgyModel } from './models.ts'
+import { AGY_PROVIDER, catalogModelList, listAgyModels, resolveAgyModel } from './models.ts'
 
-export interface AgyAccountSession {
-  auth: OAuthAuthDetails
-  account: ManagedAccount
-  index: number
-  /** Fingerprint + randomized impersonation headers for this request. */
-  impersonation: {
-    'User-Agent': string
-    'X-Goog-Api-Client': string
-    'Client-Metadata': string
-  }
-}
+export type { AgyAccountSession }
 
 export interface AgyAdapterOptions {
   /** Resolve the active account for a request (model-aware: family-scoped quota ranking). */
@@ -90,8 +81,15 @@ export class AgyAdapter extends LlmAdapter {
   }
 
   override async listModels(_provider: string): Promise<readonly LlmModelInfo[]> {
-    const session = await this.options.getSession()
-    return listAgyModels(session?.auth.access, session?.account.projectId)
+    try {
+      const session = await this.options.getSession()
+      return await listAgyModels(session?.auth.access, session?.account.projectId)
+    } catch (error) {
+      if (error instanceof AgyPoolBlockedError || error instanceof AgyAuthError) {
+        return catalogModelList()
+      }
+      throw error
+    }
   }
 
   override async resolveModel(provider: string, model: string): Promise<LlmResolvedModelInfo> {
@@ -99,7 +97,34 @@ export class AgyAdapter extends LlmAdapter {
   }
 
   override async *stream(options: GenerateOptions): AsyncIterable<StreamChunk> {
-    const session = await this.options.getSession(options.model)
+    let session: AgyAccountSession | undefined
+    try {
+      session = await this.options.getSession(options.model)
+    } catch (error) {
+      if (error instanceof AgyAuthError) {
+        if (error.kind === 'transport') {
+          throw new LlmError(error.message, 'TRANSPORT', { cause: error })
+        }
+        if (error.kind === 'rate-limit') {
+          throw new LlmError(error.message, 'RATE_LIMIT', {
+            requestId: ProviderRequestId(generateAntigravityRequestId()),
+          })
+        }
+        throw new LlmError(error.message, 'INVALID_CREDENTIAL', { cause: error })
+      }
+      if (error instanceof AgyPoolBlockedError) {
+        if (error.kind === 'quota-exhausted') {
+          throw new LlmError(error.message, QUOTA_EXCEEDED_CODE)
+        }
+        const delta = Math.ceil(error.blockedUntil - Date.now())
+        const providerRetryAfterMs = Number.isFinite(delta) && delta > 0 ? delta : 1
+        throw new LlmError(error.message, 'RATE_LIMIT', {
+          providerRetryAfterMs,
+          requestId: ProviderRequestId(generateAntigravityRequestId()),
+        })
+      }
+      throw error
+    }
     if (!session) {
       throw new LlmError(
         'No agy account configured — run `dsh-agy login` to authenticate.',

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -43,13 +43,21 @@ export interface AgyAccountSession {
 }
 
 export interface AgyAdapterOptions {
-  /** Resolve the active account (shell refreshes expired tokens and switches on rotation). */
-  getSession(): Promise<AgyAccountSession | undefined>
+  /** Resolve the active account for a request (model-aware: family-scoped quota ranking). */
+  getSession(model?: string): Promise<AgyAccountSession | undefined>
   /** Report a classified upstream failure so the shell can cool/rotate/revoke. */
   reportFailure(
     kind: FailureKind,
     session: AgyAccountSession,
-    info?: { retryAfterMs?: number; status?: number; rateLimitCategory?: RateLimitCategory },
+    info?: {
+      retryAfterMs?: number
+      status?: number
+      rateLimitCategory?: RateLimitCategory
+      /** Server-reported absolute reset time; drives precise cooldowns. */
+      resetTime?: string
+      /** Requested model id; drives family-scoped rate-limit bookkeeping. */
+      model?: string
+    },
   ): Promise<void>
   /** Report a clean stream completion (resets the failure counter). */
   markSuccess?(session: AgyAccountSession): Promise<void>
@@ -91,7 +99,7 @@ export class AgyAdapter extends LlmAdapter {
   }
 
   override async *stream(options: GenerateOptions): AsyncIterable<StreamChunk> {
-    const session = await this.options.getSession()
+    const session = await this.options.getSession(options.model)
     if (!session) {
       throw new LlmError(
         'No agy account configured — run `dsh-agy login` to authenticate.',
@@ -126,6 +134,8 @@ export class AgyAdapter extends LlmAdapter {
         retryAfterMs: classified.retryAfterMs,
         status: response.status,
         rateLimitCategory: classified.rateLimitCategory,
+        resetTime: classified.resetTime,
+        model: options.model,
       })
       if (classified.kind === 'rate-limit') {
         // soft/rate limits are retryable by the harness (RATE_LIMIT + delay);

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -4,7 +4,7 @@
  * and persist into the account store. Adapted from OmniRoute's agyAuthImport
  * (MIT, see NOTICE.md).
  */
-
+import { randomUUID } from 'node:crypto'
 import { AGY_ENDPOINT_FALLBACKS, getAgyBootstrapClientMetadata, getAgyBootstrapUserAgent } from '../oauth/constants.ts'
 import { decodeCredentialBlob } from '../oauth/blob.ts'
 import { proxiedFetch } from '../proxy.ts'
@@ -29,13 +29,14 @@ export interface ParsedAgyAuth {
   tokenType: string
   expiresAt: string | null
   authMethod: string | null
+  clientId?: string | null
 }
 
 export interface EnrichedAgyAuth extends ParsedAgyAuth {
   email: string | null
   projectId: string | null
+  clientId?: string | null
 }
-
 function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
 }
@@ -74,6 +75,7 @@ export function parseAndValidateAgyToken(raw: unknown): ParsedAgyAuth {
     tokenType: toNonEmptyString(token.token_type) ?? 'Bearer',
     expiresAt,
     authMethod: toNonEmptyString(doc.auth_method) ?? toNonEmptyString(token.auth_method),
+    clientId: toNonEmptyString(token.client_id) ?? toNonEmptyString(doc.client_id) ?? toNonEmptyString(token.clientId) ?? toNonEmptyString(doc.clientId),
   }
 }
 
@@ -131,7 +133,12 @@ export async function enrichWithAntigravityBackend(parsed: ParsedAgyAuth): Promi
     clearTimeout(loadTimer)
   }
 
-  return { ...parsed, email, projectId }
+  return {
+    ...parsed,
+    email,
+    projectId,
+    clientId: parsed.clientId ?? null,
+  }
 }
 
 /** Parse either a raw token document or a paste blob into an enriched account. */
@@ -192,8 +199,10 @@ export async function upsertImportedAccount(
       const existing = storage.accounts[existingIndex]!
       storage.accounts[existingIndex] = {
         ...existing,
+        id: existing.id || randomUUID(),
         refresh,
         email: existing.email ?? resolvedEmail ?? undefined,
+        clientId: enriched.clientId ? enriched.clientId : existing.clientId,
         addedAt: existing.addedAt,
         lastUsed: Date.now(),
         enabled: true,
@@ -205,9 +214,11 @@ export async function upsertImportedAccount(
     }
 
     const account: ManagedAccount = {
+      id: randomUUID(),
       email: resolvedEmail ?? undefined,
       refresh,
       projectId: enriched.projectId ?? undefined,
+      clientId: enriched.clientId ?? undefined,
       addedAt: Date.now(),
       lastUsed: Date.now(),
       enabled: true,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { createAesGcmCodec, deriveKey, loadMasterKey, resolveDshHome, resolveMas
 import type { SecretCodec } from '../store/keyring.ts'
 import { JsonAccountStore } from '../store/accounts.ts'
 import { AgySessionManager } from '../session.ts'
+import { isAgyDisabled } from '../runtime/risk.ts'
 import { startCallbackServer, openBrowser } from './callback-server.ts'
 import { importManySources, upsertImportedAccount } from './import.ts'
 
@@ -267,6 +268,35 @@ async function verifyCommand(options: { index?: string }) {
   }
 }
 
+async function healthCommand(options: { interval?: string; index?: string[] }) {
+  const store = createReadOnlyStoreOrExit()
+  const sessions = new AgySessionManager({
+    store,
+    onHealthReport: (results) => {
+      for (const result of results) {
+        if (result.ok) console.log(`[${result.index}] ${result.email ?? ''} — OK`)
+        else console.log(`[${result.index}] ${result.email ?? ''} — FAILED: ${result.error}`)
+      }
+    },
+  })
+  const indices = options.index?.map((value) => Number(value))
+
+  if (options.interval) {
+    const intervalMs = Number(options.interval)
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+      console.error('Error: --interval must be a positive number of milliseconds.')
+      process.exit(1)
+    }
+    console.log(`Health probe every ${intervalMs}ms (Ctrl+C to stop).`)
+    sessions.startHealthProbe(intervalMs, { unref: false })
+    await new Promise<void>(() => {}) // keep the loop alive
+    return
+  }
+
+  const results = await sessions.checkAccounts(indices)
+  if (results.length === 0) console.log('No enabled accounts — run `dsh-agy login` first.')
+}
+
 async function logoutCommand(options: { index?: string; email?: string }) {
   const store = createReadOnlyStoreOrExit()
   await store.mutate((storage) => {
@@ -290,6 +320,13 @@ export function createProgram(): Command {
     .name('dsh-agy')
     .description('Google Antigravity (agy) account management for DeepSeek Harness')
     .version(PACKAGE_VERSION)
+
+  program.hook('preAction', () => {
+    if (isAgyDisabled()) {
+      console.error('dsh-agy is disabled (DSH_AGY_DISABLE=1).')
+      process.exit(1)
+    }
+  })
 
   program
     .command('login')
@@ -336,6 +373,15 @@ export function createProgram(): Command {
     .option('--index <n>', 'verify one account by index; default all')
     .action(async (options: { index?: string }) => {
       await verifyCommand(options)
+    })
+
+  program
+    .command('health')
+    .description('Check every enabled account (refresh + userinfo), optionally on an interval')
+    .option('--interval <ms>', 'repeat on an interval instead of once')
+    .option('--index <n...>', 'check only these accounts')
+    .action(async (options: { interval?: string; index?: string[] }) => {
+      await healthCommand(options)
     })
 
   program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -143,6 +143,7 @@ async function loginCommand(options: { headless: boolean; blob: boolean; port: n
       authMethod: 'oauth',
       email: result.email ?? null,
       projectId: result.projectId || null,
+      clientId: result.clientId || null,
     }, { overwriteExisting: true })
     console.log(`${created ? 'Added' : 'Updated'} account: ${account.email ?? '(no email)'} (project: ${result.projectId || 'default'})`)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,17 @@
 
 import type { Context } from '@deepseek-ai/cordis'
 import { AGY_PROVIDER, createAgyRuntime } from './plugin-common.ts'
+import { isAgyDisabled } from './runtime/risk.ts'
 
 export const name = 'dsh-agy'
 
 export const inject = ['llm']
 
 export function apply(ctx: Context): void {
+  if (isAgyDisabled()) {
+    ctx.logger.warn('[dsh-agy] disabled by DSH_AGY_DISABLE=1 — skipping registration')
+    return
+  }
   ctx.effect(async () => {
     const { adapter } = await createAgyRuntime(ctx)
     const registration = ctx.llm.registerAdapter([AGY_PROVIDER], adapter)

--- a/src/oauth/authorize.ts
+++ b/src/oauth/authorize.ts
@@ -1,9 +1,9 @@
 /** Build the Antigravity OAuth authorization URL with PKCE and project metadata. */
 
 import {
-  AGY_CLIENT_ID,
   AGY_SCOPES,
   OAUTH_AUTHORIZE_URL,
+  resolveAgyClientCredentials,
 } from './constants.ts'
 import { encodeState, generatePkcePair } from './pkce.ts'
 
@@ -29,7 +29,8 @@ export async function authorizeAntigravity(
   const { verifier, challenge } = generatePkcePair()
 
   const url = new URL(OAUTH_AUTHORIZE_URL)
-  url.searchParams.set('client_id', AGY_CLIENT_ID)
+  const { clientId } = resolveAgyClientCredentials()
+  url.searchParams.set('client_id', clientId)
   url.searchParams.set('response_type', 'code')
   url.searchParams.set('redirect_uri', redirectUri)
   url.searchParams.set('scope', AGY_SCOPES.join(' '))

--- a/src/oauth/constants.ts
+++ b/src/oauth/constants.ts
@@ -14,6 +14,18 @@ export const AGY_CLIENT_ID =
 
 export const AGY_CLIENT_SECRET = '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'
 
+/**
+ * Effective OAuth client credentials: AGY_CLIENT_ID / AGY_CLIENT_SECRET env
+ * overrides win when set (BYO OAuth app escape hatch, mirrors pi-antigravity);
+ * otherwise the embedded public Antigravity credentials are used.
+ */
+export function resolveAgyClientCredentials(): { clientId: string; clientSecret: string } {
+  return {
+    clientId: process.env.AGY_CLIENT_ID || AGY_CLIENT_ID,
+    clientSecret: process.env.AGY_CLIENT_SECRET || AGY_CLIENT_SECRET,
+  }
+}
+
 /** Required scopes. `openid` must NOT be added: it routes Google into the hanging
  * `firstparty/nativeapp` consent for this client (verified by OmniRoute). */
 export const AGY_SCOPES: readonly string[] = [

--- a/src/oauth/constants.ts
+++ b/src/oauth/constants.ts
@@ -19,7 +19,16 @@ export const AGY_CLIENT_SECRET = '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'
  * overrides win when set (BYO OAuth app escape hatch, mirrors pi-antigravity);
  * otherwise the embedded public Antigravity credentials are used.
  */
-export function resolveAgyClientCredentials(): { clientId: string; clientSecret: string } {
+export function resolveAgyClientCredentials(overrideClientId?: string): { clientId: string; clientSecret: string } {
+  if (overrideClientId) {
+    if (overrideClientId === AGY_CLIENT_ID) {
+      return { clientId: AGY_CLIENT_ID, clientSecret: AGY_CLIENT_SECRET }
+    }
+    return {
+      clientId: overrideClientId,
+      clientSecret: process.env.AGY_CLIENT_SECRET || AGY_CLIENT_SECRET,
+    }
+  }
   return {
     clientId: process.env.AGY_CLIENT_ID || AGY_CLIENT_ID,
     clientSecret: process.env.AGY_CLIENT_SECRET || AGY_CLIENT_SECRET,

--- a/src/oauth/exchange.ts
+++ b/src/oauth/exchange.ts
@@ -278,6 +278,7 @@ export async function exchangeAntigravity(
       expires: calculateTokenExpiry(startTime, tokenPayload.expires_in),
       email: userInfo.email,
       projectId: effectiveProjectId || '',
+      clientId,
     }
   } catch (error) {
     const failure: TokenExchangeFailure = {

--- a/src/oauth/exchange.ts
+++ b/src/oauth/exchange.ts
@@ -7,13 +7,12 @@
 import type { TokenExchangeFailure, TokenExchangeResult } from '../types.ts'
 import { calculateTokenExpiry } from './auth.ts'
 import {
-  AGY_CLIENT_ID,
-  AGY_CLIENT_SECRET,
   AGY_ENDPOINT_FALLBACKS,
   OAUTH_TOKEN_URL,
   OAUTH_USERINFO_URL,
   getAgyBootstrapClientMetadata,
   getAgyBootstrapUserAgent,
+  resolveAgyClientCredentials,
 } from './constants.ts'
 import { decodeState } from './pkce.ts'
 import { proxiedFetch } from '../proxy.ts'
@@ -230,6 +229,7 @@ export async function exchangeAntigravity(
     }
 
     const startTime = Date.now()
+    const { clientId, clientSecret } = resolveAgyClientCredentials()
     const tokenResponse = await proxiedFetch(OAUTH_TOKEN_URL, {
       method: 'POST',
       headers: {
@@ -238,8 +238,8 @@ export async function exchangeAntigravity(
         'User-Agent': getAgyBootstrapUserAgent(),
       },
       body: new URLSearchParams({
-        client_id: AGY_CLIENT_ID,
-        client_secret: AGY_CLIENT_SECRET,
+        client_id: clientId,
+        client_secret: clientSecret,
         code,
         grant_type: 'authorization_code',
         redirect_uri: redirectUri,

--- a/src/oauth/refresh.ts
+++ b/src/oauth/refresh.ts
@@ -5,7 +5,7 @@
 
 import type { OAuthAuthDetails } from '../types.ts'
 import { calculateTokenExpiry, formatRefreshParts, parseRefreshParts } from './auth.ts'
-import { AGY_CLIENT_ID, AGY_CLIENT_SECRET, OAUTH_TOKEN_URL } from './constants.ts'
+import { AGY_CLIENT_ID, AGY_CLIENT_SECRET, OAUTH_TOKEN_URL, resolveAgyClientCredentials } from './constants.ts'
 import { proxiedFetch } from '../proxy.ts'
 
 interface OAuthErrorPayload {
@@ -95,6 +95,7 @@ export async function refreshAccessToken(auth: OAuthAuthDetails): Promise<Refres
 
   try {
     const startTime = Date.now()
+    const { clientId, clientSecret } = resolveAgyClientCredentials()
     const response = await proxiedFetch(OAUTH_TOKEN_URL, {
       method: 'POST',
       headers: {
@@ -103,8 +104,8 @@ export async function refreshAccessToken(auth: OAuthAuthDetails): Promise<Refres
       body: new URLSearchParams({
         grant_type: 'refresh_token',
         refresh_token: parts.refreshToken,
-        client_id: AGY_CLIENT_ID,
-        client_secret: AGY_CLIENT_SECRET,
+        client_id: clientId,
+        client_secret: clientSecret,
       }),
     })
 

--- a/src/oauth/refresh.ts
+++ b/src/oauth/refresh.ts
@@ -5,7 +5,7 @@
 
 import type { OAuthAuthDetails } from '../types.ts'
 import { calculateTokenExpiry, formatRefreshParts, parseRefreshParts } from './auth.ts'
-import { AGY_CLIENT_ID, AGY_CLIENT_SECRET, OAUTH_TOKEN_URL, resolveAgyClientCredentials } from './constants.ts'
+import { AGY_CLIENT_ID, OAUTH_TOKEN_URL, resolveAgyClientCredentials } from './constants.ts'
 import { proxiedFetch } from '../proxy.ts'
 
 interface OAuthErrorPayload {
@@ -75,15 +75,17 @@ export function parseOAuthErrorPayload(text: string | undefined): { code?: strin
 }
 
 export type RefreshResult =
-  | { type: 'success'; auth: OAuthAuthDetails }
+  | { type: 'success'; auth: OAuthAuthDetails; clientId: string }
   | { type: 'revoked' }
   | { type: 'failed'; error: AgyTokenRefreshError }
 
 /**
  * Refresh the access token for an account. `revoked` means Google rejected the
  * refresh token (`invalid_grant`) — the account must be re-authenticated.
+ * For legacy accounts without a stored clientId, embedded credentials are tried
+ * first with an env-override fallback before treating invalid_grant as fatal.
  */
-export async function refreshAccessToken(auth: OAuthAuthDetails): Promise<RefreshResult> {
+export async function refreshAccessToken(auth: OAuthAuthDetails, options?: { clientId?: string }): Promise<RefreshResult> {
   const parts = parseRefreshParts(auth.refresh)
   if (!parts.refreshToken) {
     return { type: 'failed', error: new AgyTokenRefreshError({
@@ -93,74 +95,100 @@ export async function refreshAccessToken(auth: OAuthAuthDetails): Promise<Refres
     }) }
   }
 
-  try {
-    const startTime = Date.now()
-    const { clientId, clientSecret } = resolveAgyClientCredentials()
-    const response = await proxiedFetch(OAUTH_TOKEN_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        grant_type: 'refresh_token',
-        refresh_token: parts.refreshToken,
-        client_id: clientId,
-        client_secret: clientSecret,
-      }),
-    })
+  // Candidate client IDs to try: explicit stored clientId first; for legacy
+  // accounts, try embedded first, then env override (if distinct).
+  const candidateIds = options?.clientId
+    ? [options.clientId]
+    : Array.from(new Set([AGY_CLIENT_ID, process.env.AGY_CLIENT_ID].filter((id): id is string => Boolean(id && id.length > 0))))
 
-    if (!response.ok) {
-      const errorText = await response.text().catch(() => undefined)
-      const { code, description } = parseOAuthErrorPayload(errorText)
-      const details = [code, description ?? errorText].filter(Boolean).join(': ')
-      const baseMessage = `Agy token refresh failed (${response.status} ${response.statusText})`
-      const message = details ? `${baseMessage} - ${details}` : baseMessage
+  let revokedCount = 0
+  let transientFailure: RefreshResult | undefined
 
-      if (code === 'invalid_grant') {
-        return { type: 'revoked' }
+  for (const currentClientId of candidateIds) {
+    try {
+      const startTime = Date.now()
+      const { clientId, clientSecret } = resolveAgyClientCredentials(currentClientId)
+      const response = await proxiedFetch(OAUTH_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: parts.refreshToken,
+          client_id: clientId,
+          client_secret: clientSecret,
+        }),
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => undefined)
+        const { code, description } = parseOAuthErrorPayload(errorText)
+        const details = [code, description ?? errorText].filter(Boolean).join(': ')
+        const baseMessage = `Agy token refresh failed (${response.status} ${response.statusText})`
+        const message = details ? `${baseMessage} - ${details}` : baseMessage
+
+        if (code === 'invalid_grant') {
+          revokedCount++
+          continue // try next candidate if available before revoking
+        }
+
+        transientFailure = {
+          type: 'failed',
+          error: new AgyTokenRefreshError({
+            message,
+            code,
+            description: description ?? errorText,
+            status: response.status,
+            statusText: response.statusText,
+          }),
+        }
+        continue
+      }
+      const payload = (await response.json()) as {
+        access_token: string
+        expires_in?: number
+        refresh_token?: string
+      }
+
+      const refreshedParts = {
+        refreshToken: payload.refresh_token ?? parts.refreshToken,
+        projectId: parts.projectId,
+        managedProjectId: parts.managedProjectId,
       }
 
       return {
+        type: 'success',
+        auth: {
+          access: payload.access_token,
+          expires: calculateTokenExpiry(startTime, payload.expires_in),
+          refresh: formatRefreshParts(refreshedParts),
+        },
+        clientId,
+      }
+    } catch (error) {
+      transientFailure = {
         type: 'failed',
         error: new AgyTokenRefreshError({
-          message,
-          code,
-          description: description ?? errorText,
-          status: response.status,
-          statusText: response.statusText,
+          message: error instanceof Error ? error.message : 'Unknown refresh error',
+          status: 0,
+          statusText: 'Network Error',
         }),
       }
     }
+  }
 
-    const payload = (await response.json()) as {
-      access_token: string
-      expires_in?: number
-      refresh_token?: string
-    }
+  // If any candidate encountered a transient / inconclusive error, do NOT revoke.
+  if (transientFailure) return transientFailure
+  // Only if ALL candidates were definitively rejected with invalid_grant, revoke.
+  if (revokedCount === candidateIds.length) return { type: 'revoked' }
 
-    const refreshedParts = {
-      refreshToken: payload.refresh_token ?? parts.refreshToken,
-      projectId: parts.projectId,
-      managedProjectId: parts.managedProjectId,
-    }
-
-    return {
-      type: 'success',
-      auth: {
-        access: payload.access_token,
-        expires: calculateTokenExpiry(startTime, payload.expires_in),
-        refresh: formatRefreshParts(refreshedParts),
-      },
-    }
-  } catch (error) {
-    if (error instanceof AgyTokenRefreshError) throw error
-    return {
-      type: 'failed',
-      error: new AgyTokenRefreshError({
-        message: error instanceof Error ? error.message : 'Unknown refresh error',
-        status: 0,
-        statusText: '',
-      }),
-    }
+  return {
+    type: 'failed',
+    error: new AgyTokenRefreshError({
+      message: 'Token refresh failed on all candidate client IDs',
+      status: 400,
+      statusText: 'Bad Request',
+    }),
   }
 }

--- a/src/plugin-common.ts
+++ b/src/plugin-common.ts
@@ -72,7 +72,7 @@ export async function createAgyRuntime(ctx: Context): Promise<{
   const store = new JsonAccountStore({ file: `${dshHome}/agy-accounts.json`, codec })
   const sessions = new AgySessionManager({ store })
   const adapter = new AgyAdapter({
-    getSession: () => sessions.getSession(),
+    getSession: (model) => sessions.getSession(model),
     reportFailure: (kind, session, info) => sessions.reportFailure(kind, session, info),
     markSuccess: (session) => sessions.markSuccess(session),
   })

--- a/src/plugin-common.ts
+++ b/src/plugin-common.ts
@@ -71,6 +71,11 @@ export async function createAgyRuntime(ctx: Context): Promise<{
   const dshHome = resolveDshHome()
   const store = new JsonAccountStore({ file: `${dshHome}/agy-accounts.json`, codec })
   const sessions = new AgySessionManager({ store })
+  // Optional background health probe (DSH_AGY_HEALTH_INTERVAL_MS), off by default.
+  const healthIntervalMs = Number(process.env.DSH_AGY_HEALTH_INTERVAL_MS ?? 0)
+  if (Number.isFinite(healthIntervalMs) && healthIntervalMs > 0) {
+    sessions.startHealthProbe(healthIntervalMs)
+  }
   const adapter = new AgyAdapter({
     getSession: (model) => sessions.getSession(model),
     reportFailure: (kind, session, info) => sessions.reportFailure(kind, session, info),

--- a/src/runtime/fingerprint.ts
+++ b/src/runtime/fingerprint.ts
@@ -103,6 +103,25 @@ export function getRandomizedHeaders(
   }
 }
 
+/**
+ * Deterministic fallback headers for the `stable` fingerprint mode: the first
+ * entry of each pool, every call — one fixed client identity instead of
+ * per-request randomization (OMP-style fixed-client posture).
+ */
+export function getStableHeaders(
+  data: FingerprintData = getFingerprintData(),
+  version = data.versionPool[0] ?? '',
+): { 'User-Agent': string; 'X-Goog-Api-Client': string; 'Client-Metadata': string } {
+  const platform = data.platforms[0] ?? 'windows/amd64'
+  return {
+    'User-Agent': `antigravity/${version || '1.18.3'} ${platform}`,
+    'X-Goog-Api-Client': data.sdkClients[0] ?? '',
+    'Client-Metadata': JSON.stringify({
+      ideType: data.ideTypes[0] ?? 'ANTIGRAVITY',
+    }),
+  }
+}
+
 /** Rewrite the version inside a fingerprint UA; reports whether it changed. */
 export function updateFingerprintVersion(fingerprint: Fingerprint, version: string): boolean {
   const pattern = /^(antigravity\/)([\d.]+)/

--- a/src/runtime/quota.ts
+++ b/src/runtime/quota.ts
@@ -165,9 +165,9 @@ export function rankPoolCandidates(
   startIndex = 0,
 ): PoolCandidate[] {
   const family = modelFamilyOf(modelId)
-  const clampedStart = entries.length === 0 ? 0 : Math.min(Math.max(startIndex, 0), entries.length - 1)
+  const activePos = entries.findIndex((e) => e.index === startIndex)
+  const clampedStart = activePos >= 0 ? activePos : 0
   const ordered = entries.length === 0 ? [] : [...entries.slice(clampedStart), ...entries.slice(0, clampedStart)]
-
   const candidates: PoolCandidateWithOrder[] = ordered.map(({ account, index }, orderPos) => {
     const quota = familyQuotaFor(account, family)
     const remaining = quota?.remainingFraction

--- a/src/runtime/quota.ts
+++ b/src/runtime/quota.ts
@@ -1,0 +1,221 @@
+/**
+ * Usage-aware account pool scheduling, aligned with oh-my-pi's
+ * google-antigravity usage provider + ranking strategy (AuthStorage):
+ *
+ * - Backend quotas are counters scoped by model family (google/anthropic/openai);
+ *   the requested model maps to one family via its id prefix.
+ * - `fetchAvailableModels` quotaInfo entries are aggregated per family
+ *   (most-pressured model wins the family's remaining fraction).
+ * - Candidates rank by: unblocked first, hot windows last, measured usage before
+ *   unmeasured, required-drain descending (headroom / hours-to-reset — "use it
+ *   or lose it"), then used-fraction ascending. Exhausted families block the
+ *   account until their real reset time.
+ */
+
+import type { DiscoveredModels } from '../adapter/models.ts'
+import type { CachedQuota, ManagedAccount } from '../types.ts'
+import { SOFT_QUOTA_THRESHOLD, computeSoftQuotaCacheTtlMs } from './rotation.ts'
+
+export type ModelFamily = 'google' | 'anthropic' | 'openai'
+
+/** Family bucket for model ids with no recognizable prefix (mirrors OMP's counter:unknown). */
+export const FAMILY_UNKNOWN = 'unknown'
+
+/** Mirrors AuthStorage.PRIMARY_WINDOW_HOT_FRACTION: near-exhausted windows rank last. */
+export const PRIMARY_WINDOW_HOT_FRACTION = 0.85
+
+const DAY_MS = 24 * 60 * 60 * 1000
+/** Floor for remaining-time in drain-urgency scores (mirrors AuthStorage; a stale reset must not explode the score). */
+const DRAIN_FLOOR_MS = 60_000
+
+/** Map a model id to its backend quota counter family (OMP getAntigravityCounterKeyForModel). */
+export function modelFamilyOf(modelId?: string): ModelFamily | undefined {
+  if (!modelId) return undefined
+  const id = modelId.toLowerCase()
+  if (id.startsWith('claude-')) return 'anthropic'
+  if (id.startsWith('gemini-') || id.startsWith('gemma-')) return 'google'
+  if (id.startsWith('gpt-') || id.startsWith('openai/')) return 'openai'
+  return undefined
+}
+
+/** Quota-cache key for a request: the model's family, or the unknown bucket. */
+export function familyKeyOf(modelId?: string): string {
+  return modelFamilyOf(modelId) ?? FAMILY_UNKNOWN
+}
+
+function earliestResetTime(a?: string, b?: string): string | undefined {
+  if (!a) return b
+  if (!b) return a
+  const ta = Date.parse(a)
+  const tb = Date.parse(b)
+  if (Number.isNaN(ta)) return b
+  if (Number.isNaN(tb)) return a
+  return ta <= tb ? a : b
+}
+
+/**
+ * Aggregate a fetchAvailableModels response into per-family quota records:
+ * the family's remaining fraction is its most-pressured model's, and the
+ * reset time is the earliest across the family (the bottleneck resets first).
+ */
+export function ingestFamilyQuotas(discovered: DiscoveredModels): Record<string, CachedQuota> {
+  const families = new Map<string, CachedQuota>()
+  for (const [modelId, entry] of Object.entries(discovered.models ?? {})) {
+    const remaining = entry.quotaInfo?.remainingFraction
+    if (typeof remaining !== 'number' || !Number.isFinite(remaining)) continue
+    const key = familyKeyOf(modelId)
+    const current = families.get(key)
+    const resetTime = earliestResetTime(current?.resetTime, entry.quotaInfo?.resetTime)
+    families.set(key, {
+      remainingFraction: current ? Math.min(current.remainingFraction ?? 1, remaining) : remaining,
+      ...(resetTime ? { resetTime } : {}),
+      modelCount: (current?.modelCount ?? 0) + 1,
+    })
+  }
+  return Object.fromEntries(families)
+}
+
+/** The quota record for one family, or the most-pressured family when the model is unknown. */
+export function familyQuotaFor(account: ManagedAccount, family?: ModelFamily): CachedQuota | undefined {
+  const cache = account.cachedQuota ?? {}
+  if (family) return cache[family]
+  let worst: CachedQuota | undefined
+  for (const entry of Object.values(cache)) {
+    if (typeof entry.remainingFraction !== 'number') continue
+    if (!worst || entry.remainingFraction < (worst.remainingFraction ?? 1)) worst = entry
+  }
+  return worst
+}
+
+/** Whether the account's quota cache needs a refresh (missing, or past its health-based TTL). */
+export function isQuotaStale(account: ManagedAccount, now = Date.now()): boolean {
+  if (!account.cachedQuota || !account.cachedQuotaUpdatedAt) return true
+  const mostPressured = familyQuotaFor(account)
+  const ttl = computeSoftQuotaCacheTtlMs(mostPressured?.remainingFraction)
+  return now - account.cachedQuotaUpdatedAt > ttl
+}
+
+/** Whether the requested family on this account is soft-quota-exhausted (below the pre-check threshold). */
+export function isFamilyDrained(account: ManagedAccount, family?: ModelFamily, now = Date.now()): boolean {
+  const quota = familyQuotaFor(account, family)
+  if (!quota || typeof quota.remainingFraction !== 'number') return false
+  if (quota.resetTime) {
+    const reset = Date.parse(quota.resetTime)
+    if (!Number.isNaN(reset) && reset <= now) return false
+  }
+  return quota.remainingFraction < SOFT_QUOTA_THRESHOLD
+}
+
+/**
+ * Required drain rate: headroomFraction / remainingHours — how fast the
+ * family's remaining quota must be consumed to avoid expiring unused at its
+ * reset (mirrors AuthStorage.#computeWindowRequiredDrain with a daily window).
+ */
+export function requiredDrainFor(quota: CachedQuota | undefined, now = Date.now()): number {
+  const remaining = quota?.remainingFraction
+  if (typeof remaining !== 'number' || !Number.isFinite(remaining)) return 0
+  // Headroom IS the remaining fraction (mirrors AuthStorage: headroom = 1 - used).
+  const headroom = Math.min(Math.max(remaining, 0), 1)
+  if (headroom <= 0) return 0
+  let remainingMs = DAY_MS
+  const resetTime = quota?.resetTime
+  if (resetTime) {
+    const resetAt = Date.parse(resetTime)
+    if (!Number.isNaN(resetAt)) remainingMs = Math.min(remainingMs, Math.max(resetAt - now, 0))
+  }
+  const remainingHours = Math.max(remainingMs, DRAIN_FLOOR_MS) / (60 * 60 * 1000)
+  return headroom / remainingHours
+}
+
+export interface PoolCandidate {
+  account: ManagedAccount
+  index: number
+  /** Cooldown/limit wall blocking this account (null when usable). */
+  blockedUntil: number | null
+  /** Used fraction of the requested family's quota (measured accounts only). */
+  usedFraction?: number
+  requiredDrain: number
+  hot: boolean
+  measured: boolean
+}
+
+/** Candidate with its rotation-order position, used only while sorting. */
+interface PoolCandidateWithOrder extends PoolCandidate {
+  orderPos: number
+}
+
+function parseFutureResetMs(resetTime: string | undefined, now: number): number | undefined {
+  if (!resetTime) return undefined
+  const reset = Date.parse(resetTime)
+  if (Number.isNaN(reset) || reset <= now) return undefined
+  return reset
+}
+
+/**
+ * Rank pool candidates for one request, mirroring AuthStorage's antigravity
+ * ordering: unblocked first (earliest unblock time among blocked), hot windows
+ * last, measured usage before unmeasured, required-drain descending, then
+ * used-fraction ascending. Ties preserve the rotation order seeded from
+ * `startIndex` so an unmeasured pool keeps the active-account bias.
+ */
+export function rankPoolCandidates(
+  entries: ReadonlyArray<{ account: ManagedAccount; index: number }>,
+  modelId: string | undefined,
+  now = Date.now(),
+  startIndex = 0,
+): PoolCandidate[] {
+  const family = modelFamilyOf(modelId)
+  const clampedStart = entries.length === 0 ? 0 : Math.min(Math.max(startIndex, 0), entries.length - 1)
+  const ordered = entries.length === 0 ? [] : [...entries.slice(clampedStart), ...entries.slice(0, clampedStart)]
+
+  const candidates: PoolCandidateWithOrder[] = ordered.map(({ account, index }, orderPos) => {
+    const quota = familyQuotaFor(account, family)
+    const remaining = quota?.remainingFraction
+    const used = typeof remaining === 'number' ? Math.min(Math.max(1 - remaining, 0), 1) : undefined
+
+    let blockedUntil: number | null = null
+    if (account.coolingDownUntil && account.coolingDownUntil > now) {
+      blockedUntil = account.coolingDownUntil
+    }
+    const familyLimit = account.rateLimitResetTimes?.[familyKeyOf(modelId)]
+    if (familyLimit !== undefined && familyLimit > now) {
+      blockedUntil = blockedUntil === null ? familyLimit : Math.max(blockedUntil, familyLimit)
+    }
+    // A measured zero-remaining family with a future reset blocks the account
+    // until the real reset (mirrors AuthStorage usage-limit blocking); drained
+    // (low but non-zero) families are ranked, not blocked.
+    if (blockedUntil === null && quota && typeof remaining === 'number' && remaining <= 0) {
+      const resetMs = parseFutureResetMs(quota.resetTime, now)
+      if (resetMs !== undefined) blockedUntil = resetMs
+    }
+
+    return {
+      account,
+      index,
+      orderPos,
+      blockedUntil,
+      usedFraction: used,
+      requiredDrain: requiredDrainFor(quota, now),
+      hot: used !== undefined && used >= PRIMARY_WINDOW_HOT_FRACTION,
+      measured: used !== undefined,
+    }
+  })
+
+  candidates.sort((left, right) => {
+    const leftBlocked = left.blockedUntil !== null
+    const rightBlocked = right.blockedUntil !== null
+    if (leftBlocked !== rightBlocked) return leftBlocked ? 1 : -1
+    if (leftBlocked && rightBlocked) return (left.blockedUntil ?? 0) - (right.blockedUntil ?? 0)
+    if (left.hot !== right.hot) return left.hot ? 1 : -1
+    if (left.measured !== right.measured) return left.measured ? -1 : 1
+    const drain = right.requiredDrain - left.requiredDrain
+    if (drain !== 0) return drain
+    const usedDiff = (left.usedFraction ?? 0.5) - (right.usedFraction ?? 0.5)
+    if (usedDiff !== 0) return usedDiff
+    return left.orderPos - right.orderPos
+  })
+
+  return candidates.map(({ account, index, blockedUntil, usedFraction, requiredDrain, hot, measured }) => ({
+    account, index, blockedUntil, usedFraction, requiredDrain, hot, measured,
+  }))
+}

--- a/src/runtime/risk.ts
+++ b/src/runtime/risk.ts
@@ -1,0 +1,37 @@
+/**
+ * Risk-control switches (compliance posture): env-gated behaviors that keep
+ * the grey-zone product honest —
+ *
+ * - DSH_AGY_DISABLE=1: global kill switch, the plugin registers nothing.
+ * - DSH_AGY_FINGERPRINT_MODE=stable: one identity per account, never
+ *   regenerated, deterministic fallback headers (OMP-style fixed-client
+ *   posture). Default `dynamic` keeps the upstream per-request randomization.
+ *
+ * The BYO OAuth app escape hatch (AGY_CLIENT_ID / AGY_CLIENT_SECRET) lives in
+ * oauth/constants.ts (resolveAgyClientCredentials) — oauth/ is a dependency
+ * leaf and must not import runtime/.
+ */
+
+export type FingerprintMode = 'dynamic' | 'stable'
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on'])
+
+function envFlag(name: string): boolean {
+  const value = process.env[name]
+  return value !== undefined && TRUE_VALUES.has(value.trim().toLowerCase())
+}
+
+/** Global kill switch: DSH_AGY_DISABLE=1 keeps the plugin from registering anything. */
+export function isAgyDisabled(): boolean {
+  return envFlag('DSH_AGY_DISABLE')
+}
+
+/**
+ * Fingerprint strategy: `dynamic` (default, upstream behavior: per-request
+ * header randomization + regeneration on repeated rate-limits) or `stable`
+ * (one identity per account, never regenerated, deterministic fallback
+ * headers — mirrors OMP's fixed-client posture).
+ */
+export function fingerprintMode(): FingerprintMode {
+  return process.env.DSH_AGY_FINGERPRINT_MODE === 'stable' ? 'stable' : 'dynamic'
+}

--- a/src/runtime/rotation.ts
+++ b/src/runtime/rotation.ts
@@ -43,9 +43,20 @@ export function isRateLimited(account: ManagedAccount, now = Date.now()): boolea
   return Object.values(times).some((reset) => typeof reset === 'number' && reset > now)
 }
 
-/** Record a rate-limit reset for one model key. */
+/** Whether the requested model family on this account is rate-limited. */
+export function isFamilyRateLimited(account: ManagedAccount, family: string | undefined, now = Date.now()): boolean {
+  if (!family) return false
+  const resetAt = account.rateLimitResetTimes?.[family]
+  return typeof resetAt === 'number' && resetAt > now
+}
+
+/** Record a rate-limit reset for one model key, retaining the latest reset time. */
 export function recordRateLimit(account: ManagedAccount, modelKey: string, resetAtMs: number): void {
-  account.rateLimitResetTimes = { ...(account.rateLimitResetTimes ?? {}), [modelKey]: resetAtMs }
+  const current = account.rateLimitResetTimes?.[modelKey] ?? 0
+  account.rateLimitResetTimes = {
+    ...(account.rateLimitResetTimes ?? {}),
+    [modelKey]: Math.max(current, resetAtMs),
+  }
 }
 
 /** Clear expired rate limits and cooldowns in place. */
@@ -115,14 +126,14 @@ export function decideRotation(
         return { action: 'cool', backoffMs: Math.max(cooldownMs, 60_000) }
       }
       // Per-minute rate limit: prefer the server's real reset (capped), then
-      // Retry-After, then the fixed short window.
+      // Retry-After, then the fixed short window. The family-scoped reset is
+      // recorded in account.rateLimitResetTimes, so other model families on
+      // this account stay unblocked (AuthStorage-aligned).
       const resetMs = parseFutureResetMs(resetTime, now)
       const cooldownMs = resetMs !== undefined
         ? Math.min(resetMs - now, MAX_RATE_LIMIT_COOLDOWN_MS)
         : (retryAfterMs ?? RATE_LIMIT_COOLDOWN_MS)
-      account.coolingDownUntil = now + Math.max(cooldownMs, 1000)
-      account.cooldownReason = undefined // per-model resets live in rateLimitResetTimes
-      return { action: 'rotate', backoffMs }
+      return { action: 'rotate', backoffMs: Math.max(cooldownMs, 1000) }
     }
     case 'auth-failure': {
       // Terminal: account credentials are dead; never auto-recover.
@@ -162,10 +173,16 @@ export function pickNextAccountIndex(
   accounts: ManagedAccount[],
   currentIndex: number,
   now = Date.now(),
+  modelOrFamily?: string,
 ): number {
   if (accounts.length <= 1) return currentIndex
   const enabled = accounts.map((a, i) => ({ account: a, index: i }))
-    .filter(({ account, index }) => index !== currentIndex && account.enabled !== false && !isCoolingDown(account, now))
+    .filter(({ account, index }) => {
+      if (index === currentIndex || account.enabled === false) return false
+      if (isCoolingDown(account, now)) return false
+      if (modelOrFamily && isFamilyRateLimited(account, modelOrFamily, now)) return false
+      return true
+    })
   if (enabled.length === 0) return currentIndex
   // Round-robin: first candidate after current index, else first eligible.
   const after = enabled.find((e) => e.index > currentIndex)

--- a/src/runtime/rotation.ts
+++ b/src/runtime/rotation.ts
@@ -122,7 +122,7 @@ export function decideRotation(
           ? Math.min(resetMs - now, FULL_QUOTA_COOLDOWN_MS)
           : FULL_QUOTA_COOLDOWN_MS
         account.coolingDownUntil = now + Math.max(cooldownMs, 60_000)
-        account.cooldownReason = undefined
+        account.cooldownReason = 'quota-exhausted'
         return { action: 'cool', backoffMs: Math.max(cooldownMs, 60_000) }
       }
       // Per-minute rate limit: prefer the server's real reset (capped), then

--- a/src/runtime/rotation.ts
+++ b/src/runtime/rotation.ts
@@ -66,6 +66,16 @@ export function clearExpiredState(account: ManagedAccount, now = Date.now()): vo
 export const FULL_QUOTA_COOLDOWN_MS = 24 * 60 * 60 * 1000
 /** 5min cooldown for per-minute rate limits. */
 export const RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000
+/** Cap for a server-reported reset time on per-minute limits (guards against bogus far-future values). */
+export const MAX_RATE_LIMIT_COOLDOWN_MS = 30 * 60 * 1000
+
+/** Absolute server-reported reset in ms when it lies in the future, else undefined. */
+export function parseFutureResetMs(resetTime: string | undefined, now = Date.now()): number | undefined {
+  if (!resetTime) return undefined
+  const reset = Date.parse(resetTime)
+  if (Number.isNaN(reset) || reset <= now) return undefined
+  return reset
+}
 
 /**
  * Decide what to do after one failed attempt.
@@ -74,6 +84,7 @@ export const RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000
  * @param account - the account that failed (mutated with cooldown/rate-limit state).
  * @param consecutiveFailures - consecutive failures on this account.
  * @param retryAfterMs - server-provided retry delay when present.
+ * @param resetTime - server-provided absolute reset time; cooldowns use it (capped) instead of fixed windows.
  */
 export function decideRotation(
   kind: FailureKind,
@@ -81,6 +92,7 @@ export function decideRotation(
   consecutiveFailures: number,
   retryAfterMs?: number,
   category: RateLimitCategory = 'unknown',
+  resetTime?: string,
 ): RotationAction {
   const now = Date.now()
   const backoffMs = backoffFor(consecutiveFailures)
@@ -92,13 +104,23 @@ export function decideRotation(
         return { action: 'retry', backoffMs: Math.min(retryAfterMs ?? backoffMs, 3000) }
       }
       if (category === 'quota_exhausted') {
-        // Daily/plan quota gone: long cooldown; a single account just waits.
-        account.coolingDownUntil = now + FULL_QUOTA_COOLDOWN_MS
+        // Daily/plan quota gone: cool until the real reset when the backend
+        // reported one (capped at 24h), else the fixed daily window.
+        const resetMs = parseFutureResetMs(resetTime, now)
+        const cooldownMs = resetMs !== undefined
+          ? Math.min(resetMs - now, FULL_QUOTA_COOLDOWN_MS)
+          : FULL_QUOTA_COOLDOWN_MS
+        account.coolingDownUntil = now + Math.max(cooldownMs, 60_000)
         account.cooldownReason = undefined
-        return { action: 'cool', backoffMs: FULL_QUOTA_COOLDOWN_MS }
+        return { action: 'cool', backoffMs: Math.max(cooldownMs, 60_000) }
       }
-      const cooldownMs = retryAfterMs ?? RATE_LIMIT_COOLDOWN_MS
-      account.coolingDownUntil = now + cooldownMs
+      // Per-minute rate limit: prefer the server's real reset (capped), then
+      // Retry-After, then the fixed short window.
+      const resetMs = parseFutureResetMs(resetTime, now)
+      const cooldownMs = resetMs !== undefined
+        ? Math.min(resetMs - now, MAX_RATE_LIMIT_COOLDOWN_MS)
+        : (retryAfterMs ?? RATE_LIMIT_COOLDOWN_MS)
+      account.coolingDownUntil = now + Math.max(cooldownMs, 1000)
       account.cooldownReason = undefined // per-model resets live in rateLimitResetTimes
       return { action: 'rotate', backoffMs }
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -28,10 +28,12 @@ import {
   DEFAULT_FINGERPRINT_DATA,
   generateFingerprint,
   getRandomizedHeaders,
+  getStableHeaders,
   recordFingerprintVersion,
   updateFingerprintVersion,
 } from './runtime/fingerprint.ts'
 import { deriveAntigravitySessionId } from './runtime/identity.ts'
+import { fingerprintMode } from './runtime/risk.ts'
 import { peekCachedAntigravityVersion, resolveAntigravityVersionBounded } from './runtime/version.ts'
 import { proxiedFetch } from './proxy.ts'
 import type { Fingerprint } from './types.ts'
@@ -40,6 +42,16 @@ export interface SessionManagerOptions {
   store: AccountStore
   /** Called after rotation changes the active index (for logging/UI). */
   onRotate?: (fromIndex: number, toIndex: number, reason: FailureKind) => void
+  /** Called after a health check finishes (batch probe results). */
+  onHealthReport?: (results: AccountHealthResult[]) => void
+}
+
+/** One account's health check result (refresh + userinfo). */
+export interface AccountHealthResult {
+  index: number
+  email?: string
+  ok: boolean
+  error?: string
 }
 
 /**
@@ -56,8 +68,8 @@ interface TokenCacheEntry {
 
 /**
  * Resolve the impersonation headers for one request from the account's
- * persistent fingerprint (stable identity), falling back to full per-request
- * randomization when the account has no fingerprint yet.
+ * persistent fingerprint (stable identity). The fallback randomizes per
+ * request in `dynamic` mode and pins one identity in `stable` mode.
  */
 export function impersonationHeadersFor(account: ManagedAccount): AgyAccountSession['impersonation'] {
   const fingerprint = account.fingerprint
@@ -68,17 +80,20 @@ export function impersonationHeadersFor(account: ManagedAccount): AgyAccountSess
       'Client-Metadata': JSON.stringify(fingerprint.clientMetadata),
     }
   }
-  const randomized = getRandomizedHeaders(DEFAULT_FINGERPRINT_DATA)
+  const headers = fingerprintMode() === 'stable'
+    ? getStableHeaders(DEFAULT_FINGERPRINT_DATA)
+    : getRandomizedHeaders(DEFAULT_FINGERPRINT_DATA)
   return {
-    'User-Agent': randomized['User-Agent'],
-    'X-Goog-Api-Client': randomized['X-Goog-Api-Client'],
-    'Client-Metadata': randomized['Client-Metadata'],
+    'User-Agent': headers['User-Agent'],
+    'X-Goog-Api-Client': headers['X-Goog-Api-Client'],
+    'Client-Metadata': headers['Client-Metadata'],
   }
 }
 
 export class AgySessionManager {
   private readonly store: AccountStore
   private readonly onRotate: SessionManagerOptions['onRotate']
+  private readonly onHealthReport: SessionManagerOptions['onHealthReport']
   private readonly tokenCache = new Map<string, TokenCacheEntry>()
   /** In-flight refresh promises keyed by account: concurrent requests share one refresh. */
   private readonly refreshInFlight = new Map<string, Promise<OAuthAuthDetails | undefined>>()
@@ -105,6 +120,7 @@ export class AgySessionManager {
   constructor(options: SessionManagerOptions) {
     this.store = options.store
     this.onRotate = options.onRotate
+    this.onHealthReport = options.onHealthReport
   }
 
   private accountKey(account: ManagedAccount): string {
@@ -338,7 +354,8 @@ export class AgySessionManager {
     // Fingerprint lifecycle: create on first rate-limit, regenerate after
     // repeated failures (bounded by history inside recordFingerprintVersion).
     // UA versions come from the version resolver (bounded, cached 6h) so
-    // fingerprints never pin a stale Antigravity client version.
+    // fingerprints never pin a stale Antigravity client version. The `stable`
+    // risk mode pins one identity per account: create once, never regenerate.
     if (kind === 'rate-limit') {
       if (!account.fingerprint) {
         account.fingerprint = generateFingerprint(undefined, await resolveAntigravityVersionBounded())
@@ -347,7 +364,7 @@ export class AgySessionManager {
         // In-place UA refresh from the cached version (no network on this path).
         const cached = peekCachedAntigravityVersion()
         if (cached) updateFingerprintVersion(account.fingerprint, cached)
-        if (consecutive >= 2) {
+        if (fingerprintMode() !== 'stable' && consecutive >= 2) {
           const fresh = generateFingerprint(undefined, await resolveAntigravityVersionBounded())
           account.fingerprintHistory = recordFingerprintVersion(account.fingerprintHistory, fresh, 'regenerated')
           account.fingerprint = fresh
@@ -439,11 +456,8 @@ export class AgySessionManager {
     }
   }
 
-  /** CLI/web helper: verify an account's credentials (refresh + userinfo). */
-  async verifyAccount(index: number): Promise<{ ok: boolean; email?: string; error?: string }> {
-    const storage = await this.store.load()
-    const account = storage.accounts[index]
-    if (!account) return { ok: false, error: 'account not found' }
+  /** Probe one account: refresh + userinfo; a live credential re-enables the account. */
+  private async probeAccount(index: number, account: ManagedAccount): Promise<{ ok: boolean; email?: string; error?: string }> {
     const auth = await this.accessTokenFor(account)
     if (!auth) return { ok: false, error: 'refresh failed (revoked?)' }
     try {
@@ -468,6 +482,47 @@ export class AgySessionManager {
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
     }
+  }
+
+  /** CLI/web helper: verify an account's credentials (refresh + userinfo). */
+  async verifyAccount(index: number): Promise<{ ok: boolean; email?: string; error?: string }> {
+    const storage = await this.store.load()
+    const account = storage.accounts[index]
+    if (!account) return { ok: false, error: 'account not found' }
+    return this.probeAccount(index, account)
+  }
+
+  /**
+   * Batch health check over all enabled accounts (or the given indices):
+   * refresh + userinfo per account, live credentials re-enable the account.
+   * Reports results through onHealthReport when a listener is registered.
+   */
+  async checkAccounts(indices?: number[]): Promise<AccountHealthResult[]> {
+    const storage = await this.store.load()
+    const targets = indices !== undefined
+      ? indices.filter((index) => storage.accounts[index])
+      : storage.accounts.map((_, index) => index).filter((index) => storage.accounts[index]!.enabled !== false)
+
+    const results: AccountHealthResult[] = await Promise.all(targets.map(async (index) => {
+      const probed = await this.probeAccount(index, storage.accounts[index]!)
+      return { index, ...probed }
+    }))
+    this.onHealthReport?.(results)
+    return results
+  }
+
+  /**
+   * Start a background health probe on an interval (disposable stop handle).
+   * The timer is unref'd unless told otherwise so harness processes can still
+   * exit; the CLI loop mode passes `unref: false`.
+   */
+  startHealthProbe(intervalMs: number, options: { unref?: boolean } = {}): () => void {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) return () => {}
+    const timer = setInterval(() => {
+      void this.checkAccounts().catch(() => {})
+    }, intervalMs)
+    if (options.unref !== false) timer.unref?.()
+    return () => clearInterval(timer)
   }
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -4,8 +4,8 @@
  * in-harness plugin shell, the CLI, and the web routes.
  */
 
-import type { AgyAccountSession } from './adapter/adapter.ts'
-import type { AccountStorageV4, CachedQuota, FailureKind, ManagedAccount, OAuthAuthDetails } from './types.ts'
+import { AgyAuthError, AgyPoolBlockedError } from './types.ts'
+import type { AccountStorageV4, AgyAccountSession, CachedQuota, FailureKind, ManagedAccount, OAuthAuthDetails } from './types.ts'
 import { refreshAccessToken } from './oauth/refresh.ts'
 import { accessTokenExpired, formatRefreshParts, parseRefreshParts } from './oauth/auth.ts'
 import type { AccountStore } from './store/accounts.ts'
@@ -22,6 +22,7 @@ import {
 } from './runtime/rotation.ts'
 import {
   familyKeyOf,
+  familyQuotaFor,
   ingestFamilyQuotas,
   isFamilyDrained,
   isQuotaStale,
@@ -165,6 +166,17 @@ export class AgySessionManager {
         this.tokenCache.set(key, { access: result.auth.access, expires: result.auth.expires })
         return result.auth
       }
+      if (result.type === 'failed') {
+        if (cached && !accessTokenExpired({ access: cached.access, expires: cached.expires, refresh: account.refresh })) {
+          return { access: cached.access, expires: cached.expires, refresh: account.refresh }
+        }
+        const kind = result.error.status === 429
+          ? 'rate-limit'
+          : result.error.status === 0 || result.error.status === 408 || result.error.status >= 500
+            ? 'transport'
+            : 'invalid-credential'
+        throw new AgyAuthError(kind, result.error.message, { cause: result.error })
+      }
       if (result.type === 'revoked') {
         // Account credentials are dead — mark it disabled and verificationRequired in the store
         this.tokenCache.delete(key)
@@ -177,12 +189,14 @@ export class AgySessionManager {
             target.verificationRequiredReason = 'auth-failure'
           }
         })
+        account.enabled = false
+        account.verificationRequired = true
+        account.verificationRequiredAt = Date.now()
+        account.verificationRequiredReason = 'auth-failure'
         return undefined
       }
-      // Transient failure: the cached token (when present) remains servable.
       return undefined
     })()
-
     this.refreshInFlight.set(key, refreshing)
     refreshing.then(
       () => this.refreshInFlight.delete(key),
@@ -247,15 +261,27 @@ export class AgySessionManager {
 
     const updates = results.filter((r): r is { key: string; quotas: Record<string, CachedQuota>; updatedAt: number } => Boolean(r && Object.keys(r.quotas).length > 0))
     if (updates.length > 0) {
-      await this.store.mutate((s) => {
-        for (const update of updates) {
-          const target = s.accounts.find((candidate) => this.accountKey(candidate) === update.key)
-          if (target) {
-            target.cachedQuota = update.quotas
-            target.cachedQuotaUpdatedAt = update.updatedAt
-          }
+      for (const update of updates) {
+        const target = storage.accounts.find((candidate) => this.accountKey(candidate) === update.key)
+        if (target) {
+          target.cachedQuota = update.quotas
+          target.cachedQuotaUpdatedAt = update.updatedAt
         }
-      })
+      }
+      try {
+        await this.store.mutate((s) => {
+          for (const update of updates) {
+            const target = s.accounts.find((candidate) => this.accountKey(candidate) === update.key)
+            if (target) {
+              target.cachedQuota = update.quotas
+              target.cachedQuotaUpdatedAt = update.updatedAt
+            }
+          }
+        })
+      } catch {
+        // Quota is a derived cache — a failed write degrades gracefully without
+        // failing the active request (next refresh cycle re-ingests).
+      }
     }
   }
 
@@ -294,10 +320,20 @@ export class AgySessionManager {
     if (eligible.length === 0) return undefined
 
     const ranked = rankPoolCandidates(eligible, model, now, storage.activeIndex)
-    const picked = ranked.find((c) => c.blockedUntil === null)
-    // Hard gating: all candidates are blocked for this family/account
-    if (!picked) return undefined
-
+    const picked = ranked.find((candidate) => candidate.blockedUntil === null)
+    if (!picked) {
+      const quotaExhausted = (account: ManagedAccount): boolean => {
+        if (account.cooldownReason === 'quota-exhausted' && (account.coolingDownUntil ?? 0) > now) return true
+        const quota = familyQuotaFor(account, family)
+        if ((quota?.remainingFraction ?? 1) > 0 || !quota?.resetTime) return false
+        const resetAt = Date.parse(quota.resetTime)
+        return !Number.isNaN(resetAt) && resetAt > now
+      }
+      const retryable = ranked.filter((candidate) => !quotaExhausted(candidate.account))
+      const blocked = retryable.length > 0 ? retryable : ranked
+      const blockedUntil = Math.min(...blocked.map((candidate) => candidate.blockedUntil ?? now))
+      throw new AgyPoolBlockedError(retryable.length > 0 ? 'retryable' : 'quota-exhausted', blockedUntil)
+    }
     if (picked.index !== storage.activeIndex) {
       storage.activeIndex = picked.index
       await this.store.mutate((s) => {
@@ -315,53 +351,63 @@ export class AgySessionManager {
    */
   async getSession(model?: string): Promise<AgyAccountSession | undefined> {
     let storage = await this.store.load()
-    const eligible = storage.accounts.filter((a) => a.enabled !== false)
-    if (eligible.length > 1) {
-      await this.refreshQuotaCache(storage)
-      // The quota refresh persists through the store; re-read so the ranking
-      // below sees the fresh cache it just wrote.
-      storage = await this.store.load()
-    }
-    const picked = await this.pickAccount(storage, model)
-    if (!picked) return undefined
-    const auth = await this.accessTokenFor(picked.account)
-    if (!auth) return undefined
+    const maxAttempts = storage.accounts.filter((account) => account.enabled !== false).length
 
-    const key = this.accountKey(picked.account)
-    if (!picked.account.projectId && !this.projectRetryFailed.has(key)) {
-      try {
-        const { loadCodeAssist } = await import('./oauth/exchange.ts')
-        const { projectId } = await loadCodeAssist(auth.access)
-        if (projectId) {
-          await this.store.mutate((s) => {
-            const account = s.accounts.find((candidate) => this.accountKey(candidate) === key)
-            if (account) {
-              account.projectId = projectId
-              // Keep the packed refresh string in sync.
-              const parts = parseRefreshParts(account.refresh)
-              account.refresh = formatRefreshParts({
-                refreshToken: parts.refreshToken,
-                projectId,
-                managedProjectId: parts.managedProjectId,
-              })
-            }
-          })
-          picked.account.projectId = projectId
-        } else {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const eligible = storage.accounts.filter((account) => account.enabled !== false)
+      if (eligible.length > 1) {
+        await this.refreshQuotaCache(storage)
+        // In-memory overlay on storage already took place in refreshQuotaCache.
+      }
+      const picked = await this.pickAccount(storage, model)
+      if (!picked) return undefined
+      const auth = await this.accessTokenFor(picked.account)
+      if (!auth) {
+        // The selected credential was revoked and disabled by accessTokenFor.
+        // Re-read and select another enabled account within this same request.
+        this.lastUsed = null
+        storage = await this.store.load()
+        continue
+      }
+
+      const key = this.accountKey(picked.account)
+      if (!picked.account.projectId && !this.projectRetryFailed.has(key)) {
+        try {
+          const { loadCodeAssist } = await import('./oauth/exchange.ts')
+          const { projectId } = await loadCodeAssist(auth.access)
+          if (projectId) {
+            await this.store.mutate((s) => {
+              const account = s.accounts.find((candidate) => this.accountKey(candidate) === key)
+              if (account) {
+                account.projectId = projectId
+                // Keep the packed refresh string in sync.
+                const parts = parseRefreshParts(account.refresh)
+                account.refresh = formatRefreshParts({
+                  refreshToken: parts.refreshToken,
+                  projectId,
+                  managedProjectId: parts.managedProjectId,
+                })
+              }
+            })
+            picked.account.projectId = projectId
+          } else {
+            this.projectRetryFailed.add(key)
+          }
+        } catch {
           this.projectRetryFailed.add(key)
         }
-      } catch {
-        this.projectRetryFailed.add(key)
+      }
+
+      this.lastUsed = { key, at: Date.now() }
+      return {
+        auth,
+        account: picked.account,
+        index: picked.index,
+        impersonation: impersonationHeadersFor(picked.account),
       }
     }
 
-    this.lastUsed = { key, at: Date.now() }
-    return {
-      auth,
-      account: picked.account,
-      index: picked.index,
-      impersonation: impersonationHeadersFor(picked.account),
-    }
+    return undefined
   }
 
   /** Adapter hook: apply rotation decisions and fingerprint regeneration. */
@@ -454,9 +500,9 @@ export class AgySessionManager {
    * Returns the collected text or a structured error message.
    */
   async testCall(model: string, prompt = 'Reply with exactly: OK', maxTokens = 1024): Promise<{ ok: boolean; text?: string; error?: string }> {
-    const session = await this.getSession(model)
-    if (!session) return { ok: false, error: 'No agy account configured — run `dsh-agy login` first.' }
     try {
+      const session = await this.getSession(model)
+      if (!session) return { ok: false, error: 'No agy account configured — run `dsh-agy login` first.' }
       const { toAgyRequestBody } = await import('./adapter/translate.ts')
       const { fetchAgyFirstOk } = await import('./oauth/constants.ts')
       const { parseAgySse } = await import('./adapter/parse.ts')

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,14 +5,18 @@
  */
 
 import type { AgyAccountSession } from './adapter/adapter.ts'
-import type { AccountStorageV4, FailureKind, ManagedAccount, OAuthAuthDetails } from './types.ts'
+import type { AccountStorageV4, CachedQuota, FailureKind, ManagedAccount, OAuthAuthDetails } from './types.ts'
 import { refreshAccessToken } from './oauth/refresh.ts'
 import { accessTokenExpired, formatRefreshParts, parseRefreshParts } from './oauth/auth.ts'
 import type { AccountStore } from './store/accounts.ts'
 import {
+  MAX_RATE_LIMIT_COOLDOWN_MS,
+  RATE_LIMIT_COOLDOWN_MS,
   clearExpiredState,
   decideRotation,
   isCoolingDown,
+  isFamilyRateLimited,
+  parseFutureResetMs,
   pickNextAccountIndex,
   recordRateLimit,
 } from './runtime/rotation.ts'
@@ -66,6 +70,12 @@ interface TokenCacheEntry {
   expires: number
 }
 
+interface QuotaRefreshResult {
+  key: string
+  quotas: Record<string, CachedQuota>
+  updatedAt: number
+}
+
 /**
  * Resolve the impersonation headers for one request from the account's
  * persistent fingerprint (stable identity). The fallback randomizes per
@@ -98,7 +108,7 @@ export class AgySessionManager {
   /** In-flight refresh promises keyed by account: concurrent requests share one refresh. */
   private readonly refreshInFlight = new Map<string, Promise<OAuthAuthDetails | undefined>>()
   /** In-flight quota fetches keyed by account: concurrent selections share one fetchAvailableModels call. */
-  private readonly quotaRefreshInFlight = new Map<string, Promise<void>>()
+  private readonly quotaRefreshInFlight = new Map<string, Promise<QuotaRefreshResult | null>>()
   private readonly failureCounts = new Map<string, number>()
   /** Accounts whose request-time project discovery already failed (no retry per request). */
   private readonly projectRetryFailed = new Set<string>()
@@ -115,7 +125,7 @@ export class AgySessionManager {
    * the turns of one conversation (OmniRoute pins by session for the same
    * reason). Cleared on rotate so a failure re-picks from activeIndex.
    */
-  private lastUsed: { index: number; at: number } | null = null
+  private lastUsed: { key: string; at: number } | null = null
 
   constructor(options: SessionManagerOptions) {
     this.store = options.store
@@ -124,7 +134,7 @@ export class AgySessionManager {
   }
 
   private accountKey(account: ManagedAccount): string {
-    return account.email ?? `idx-${account.refresh}`
+    return account.id ?? account.email ?? `idx-${account.refresh}`
   }
 
   /**
@@ -138,15 +148,35 @@ export class AgySessionManager {
     if (inFlight) return inFlight
 
     const refreshing = (async (): Promise<OAuthAuthDetails | undefined> => {
-      const result = await refreshAccessToken({ access: cached?.access ?? '', expires: cached?.expires ?? 0, refresh: account.refresh })
+      const result = await refreshAccessToken(
+        { access: cached?.access ?? '', expires: cached?.expires ?? 0, refresh: account.refresh },
+        { clientId: account.clientId },
+      )
       if (result.type === 'success') {
+        if (!account.clientId && result.clientId) {
+          await this.store.mutate((s) => {
+            const target = s.accounts.find((candidate) => this.accountKey(candidate) === key)
+            if (!target) throw new Error(`Account ${key} not found during clientId migration`)
+            target.clientId = result.clientId
+          })
+          account.clientId = result.clientId
+        }
+        // Cache token strictly AFTER disk persistence has succeeded
         this.tokenCache.set(key, { access: result.auth.access, expires: result.auth.expires })
         return result.auth
       }
       if (result.type === 'revoked') {
-        // Account credentials are dead — mark it disabled; the next failure path
-        // will surface the message.
+        // Account credentials are dead — mark it disabled and verificationRequired in the store
         this.tokenCache.delete(key)
+        await this.store.mutate((s) => {
+          const target = s.accounts.find((candidate) => this.accountKey(candidate) === key)
+          if (target) {
+            target.enabled = false
+            target.verificationRequired = true
+            target.verificationRequiredAt = Date.now()
+            target.verificationRequiredReason = 'auth-failure'
+          }
+        })
         return undefined
       }
       // Transient failure: the cached token (when present) remains servable.
@@ -187,13 +217,13 @@ export class AgySessionManager {
     const stale = storage.accounts.filter((account) => account.enabled !== false && isQuotaStale(account, now))
     if (stale.length === 0) return
 
-    await Promise.all(stale.map(async (account) => {
+    const results = await Promise.all(stale.map(async (account) => {
       const key = this.accountKey(account)
       if (this.quotaRefreshInFlight.has(key)) return this.quotaRefreshInFlight.get(key)
       const refresh = (async () => {
         try {
           const auth = await this.accessTokenFor(account)
-          if (!auth) return
+          if (!auth) return null
           const { fetchAvailableModels } = await import('./adapter/models.ts')
           const boundedFetch: typeof fetch = (input, init) => {
             const timeout = AbortSignal.timeout(AgySessionManager.QUOTA_FETCH_TIMEOUT_MS)
@@ -202,25 +232,31 @@ export class AgySessionManager {
           }
           const discovered = await fetchAvailableModels(auth.access, account.projectId, boundedFetch)
           const quotas = ingestFamilyQuotas(discovered)
-          const updatedAt = Date.now()
-          await this.store.mutate((s) => {
-            const target = s.accounts.find((candidate) => this.accountKey(candidate) === key)
-            if (target) {
-              if (Object.keys(quotas).length > 0) target.cachedQuota = quotas
-              target.cachedQuotaUpdatedAt = updatedAt
-            }
-          })
+          return { key, quotas, updatedAt: Date.now() }
         } catch {
-          // quota stays unmeasured — ranking falls back to rotation order
+          return null
         }
       })()
       this.quotaRefreshInFlight.set(key, refresh)
       try {
-        await refresh
+        return await refresh
       } finally {
         this.quotaRefreshInFlight.delete(key)
       }
     }))
+
+    const updates = results.filter((r): r is { key: string; quotas: Record<string, CachedQuota>; updatedAt: number } => Boolean(r && Object.keys(r.quotas).length > 0))
+    if (updates.length > 0) {
+      await this.store.mutate((s) => {
+        for (const update of updates) {
+          const target = s.accounts.find((candidate) => this.accountKey(candidate) === update.key)
+          if (target) {
+            target.cachedQuota = update.quotas
+            target.cachedQuotaUpdatedAt = update.updatedAt
+          }
+        }
+      })
+    }
   }
 
   /**
@@ -233,32 +269,43 @@ export class AgySessionManager {
     for (const account of storage.accounts) clearExpiredState(account, now)
 
     const family = modelFamilyOf(model)
+    const familyKey = familyKeyOf(model)
     // Session affinity (time-window approximation): reuse the last-used account
     // while it is fresh and healthy, so one conversation stays on one account
     // (upstream prefix cache + sessionId continuity). A drained family or a
     // cooldown breaks the pin and re-ranks, mirroring OMP's pinned-until-unusable.
     if (this.lastUsed && now - this.lastUsed.at < SESSION_AFFINITY_WINDOW_MS) {
-      const last = storage.accounts[this.lastUsed.index]
-      if (last && last.enabled !== false && !isCoolingDown(last, now) && !isFamilyDrained(last, family)) {
-        return { account: last, index: this.lastUsed.index }
+      const lastIndex = storage.accounts.findIndex((a) => this.accountKey(a) === this.lastUsed!.key)
+      if (lastIndex !== -1) {
+        const last = storage.accounts[lastIndex]!
+        if (
+          last.enabled !== false &&
+          !isCoolingDown(last, now) &&
+          !isFamilyRateLimited(last, familyKey, now) &&
+          !isFamilyDrained(last, family, now)
+        ) {
+          return { account: last, index: lastIndex }
+        }
       }
     }
-
     const eligible = storage.accounts
       .map((account, index) => ({ account, index }))
       .filter(({ account }) => account.enabled !== false)
     if (eligible.length === 0) return undefined
-    if (eligible.length === 1) return eligible[0]
 
-    const [picked] = rankPoolCandidates(eligible, model, now, storage.activeIndex)
-    if (!picked) return eligible[0]
+    const ranked = rankPoolCandidates(eligible, model, now, storage.activeIndex)
+    const picked = ranked.find((c) => c.blockedUntil === null)
+    // Hard gating: all candidates are blocked for this family/account
+    if (!picked) return undefined
+
     if (picked.index !== storage.activeIndex) {
       storage.activeIndex = picked.index
-      await this.store.save(storage)
+      await this.store.mutate((s) => {
+        s.activeIndex = picked.index
+      })
     }
     return { account: picked.account, index: picked.index }
   }
-
   /**
    * Adapter hook: resolve the active session (refresh if needed), healing a
    * missing projectId at request time — the OAuth-time loadCodeAssist may have
@@ -267,14 +314,16 @@ export class AgySessionManager {
    * @param model - requested model id; drives family-scoped quota ranking.
    */
   async getSession(model?: string): Promise<AgyAccountSession | undefined> {
-    const initial = await this.store.load()
-    await this.refreshQuotaCache(initial)
-    // The quota refresh persists through the store; re-read so the ranking
-    // below sees the fresh cache it just wrote.
-    const storage = await this.store.load()
+    let storage = await this.store.load()
+    const eligible = storage.accounts.filter((a) => a.enabled !== false)
+    if (eligible.length > 1) {
+      await this.refreshQuotaCache(storage)
+      // The quota refresh persists through the store; re-read so the ranking
+      // below sees the fresh cache it just wrote.
+      storage = await this.store.load()
+    }
     const picked = await this.pickAccount(storage, model)
     if (!picked) return undefined
-
     const auth = await this.accessTokenFor(picked.account)
     if (!auth) return undefined
 
@@ -285,7 +334,7 @@ export class AgySessionManager {
         const { projectId } = await loadCodeAssist(auth.access)
         if (projectId) {
           await this.store.mutate((s) => {
-            const account = s.accounts[picked.index]
+            const account = s.accounts.find((candidate) => this.accountKey(candidate) === key)
             if (account) {
               account.projectId = projectId
               // Keep the packed refresh string in sync.
@@ -306,7 +355,7 @@ export class AgySessionManager {
       }
     }
 
-    this.lastUsed = { index: picked.index, at: Date.now() }
+    this.lastUsed = { key, at: Date.now() }
     return {
       auth,
       account: picked.account,
@@ -329,62 +378,70 @@ export class AgySessionManager {
       model?: string
     },
   ): Promise<void> {
-    const storage = await this.store.load()
-    const account = storage.accounts[session.index]
-    if (!account) return
-
-    const key = this.accountKey(account)
+    if (!session?.account) return
+    const key = this.accountKey(session.account)
     const consecutive = (this.failureCounts.get(key) ?? 0) + 1
     this.failureCounts.set(key, consecutive)
+    let nextIndexToRotate: number | null = null
+    const fpCachedVersion = kind === 'rate-limit' ? peekCachedAntigravityVersion() : null
+    const fpResolvedVersion = (kind === 'rate-limit' && !fpCachedVersion) ? await resolveAntigravityVersionBounded() : (fpCachedVersion ?? '1.18.3')
 
-    const decision = decideRotation(kind, account, consecutive, info?.retryAfterMs, info?.rateLimitCategory, info?.resetTime)
+    await this.store.mutate((storage) => {
+      const account = storage.accounts.find((a) => this.accountKey(a) === key)
+      if (!account) return
 
-    if (kind === 'rate-limit' && info?.resetTime) {
-      // Family-scoped bookkeeping of the real reset (display + ranking wall).
-      recordRateLimit(account, familyKeyOf(info?.model), Date.parse(info.resetTime) || Date.now() + 60_000)
-    }
+      const decision = decideRotation(kind, account, consecutive, info?.retryAfterMs, info?.rateLimitCategory, info?.resetTime)
 
-    if (decision.action === 'revoke') {
-      this.tokenCache.delete(key)
-      this.failureCounts.delete(key)
-      await this.store.save(storage)
-      return
-    }
+      if (kind === 'rate-limit' && info?.rateLimitCategory !== 'soft_rate_limit') {
+        // Family-scoped bookkeeping of the real reset (display + ranking wall).
+        // Soft rate limits are transient bursts handled via immediate retry — do not block the family.
+        const familyKey = familyKeyOf(info?.model)
+        const resetMs = parseFutureResetMs(info?.resetTime, Date.now()) ??
+          (Date.now() + Math.min(info?.retryAfterMs ?? RATE_LIMIT_COOLDOWN_MS, MAX_RATE_LIMIT_COOLDOWN_MS))
+        recordRateLimit(account, familyKey, resetMs)
+      }
 
-    // Fingerprint lifecycle: create on first rate-limit, regenerate after
-    // repeated failures (bounded by history inside recordFingerprintVersion).
-    // UA versions come from the version resolver (bounded, cached 6h) so
-    // fingerprints never pin a stale Antigravity client version. The `stable`
-    // risk mode pins one identity per account: create once, never regenerate.
-    if (kind === 'rate-limit') {
-      if (!account.fingerprint) {
-        account.fingerprint = generateFingerprint(undefined, await resolveAntigravityVersionBounded())
-        account.fingerprintHistory = recordFingerprintVersion(account.fingerprintHistory, account.fingerprint, 'initial')
-      } else {
-        // In-place UA refresh from the cached version (no network on this path).
-        const cached = peekCachedAntigravityVersion()
-        if (cached) updateFingerprintVersion(account.fingerprint, cached)
-        if (fingerprintMode() !== 'stable' && consecutive >= 2) {
-          const fresh = generateFingerprint(undefined, await resolveAntigravityVersionBounded())
-          account.fingerprintHistory = recordFingerprintVersion(account.fingerprintHistory, fresh, 'regenerated')
-          account.fingerprint = fresh
+      if (decision.action === 'revoke') {
+        this.tokenCache.delete(key)
+        this.failureCounts.delete(key)
+        return
+      }
+
+      // Fingerprint lifecycle: create on first rate-limit, regenerate after
+      // repeated failures (bounded by history inside recordFingerprintVersion).
+      // UA versions come from the version resolver (bounded, cached 6h) so
+      // fingerprints never pin a stale Antigravity client version. The `stable`
+      // risk mode pins one identity per account: create once, never regenerate.
+      if (kind === 'rate-limit' && info?.rateLimitCategory !== 'soft_rate_limit') {
+        if (!account.fingerprint) {
+          account.fingerprint = generateFingerprint(undefined, fpResolvedVersion)
+          account.fingerprintHistory = recordFingerprintVersion(account.fingerprintHistory, account.fingerprint, 'initial')
+        } else {
+          if (fpCachedVersion) updateFingerprintVersion(account.fingerprint, fpCachedVersion)
+          if (fingerprintMode() !== 'stable' && consecutive >= 2) {
+            const fresh = generateFingerprint(undefined, fpResolvedVersion)
+            account.fingerprintHistory = recordFingerprintVersion(account.fingerprintHistory, fresh, 'regenerated')
+            account.fingerprint = fresh
+          }
         }
       }
-    }
 
-    if (decision.action === 'rotate') {
-      const nextIndex = pickNextAccountIndex(storage.accounts, session.index)
-      if (nextIndex !== session.index) {
-        storage.activeIndex = nextIndex
-        this.onRotate?.(session.index, nextIndex, kind)
+      if (decision.action === 'rotate') {
+        const currentIndex = storage.accounts.findIndex((a) => this.accountKey(a) === key)
+        const familyKey = familyKeyOf(info?.model)
+        const nextIndex = pickNextAccountIndex(storage.accounts, currentIndex >= 0 ? currentIndex : storage.activeIndex, Date.now(), familyKey)
+        if (nextIndex !== storage.activeIndex) {
+          storage.activeIndex = nextIndex
+          nextIndexToRotate = nextIndex
+        }
+        this.lastUsed = null
       }
-      // The pinned account failed — drop the affinity so the pool re-balances.
-      this.lastUsed = null
+    })
+
+    if (nextIndexToRotate !== null) {
+      this.onRotate?.(session.index, nextIndexToRotate, kind)
     }
-
-    await this.store.save(storage)
   }
-
   /** Adapter hook: reset the failure counter after a clean completion. */
   async markSuccess(session: AgyAccountSession): Promise<void> {
     const account = session.account
@@ -397,7 +454,7 @@ export class AgySessionManager {
    * Returns the collected text or a structured error message.
    */
   async testCall(model: string, prompt = 'Reply with exactly: OK', maxTokens = 1024): Promise<{ ok: boolean; text?: string; error?: string }> {
-    const session = await this.getSession()
+    const session = await this.getSession(model)
     if (!session) return { ok: false, error: 'No agy account configured — run `dsh-agy login` first.' }
     try {
       const { toAgyRequestBody } = await import('./adapter/translate.ts')

--- a/src/session.ts
+++ b/src/session.ts
@@ -90,6 +90,8 @@ export class AgySessionManager {
 
   /** Bound for one quota poll so selection never stalls on a hung endpoint. */
   private static readonly QUOTA_FETCH_TIMEOUT_MS = 3_000
+  /** Refresh the token this far ahead of expiry so a request never blocks on the token endpoint. */
+  private static readonly REFRESH_SKEW_MS = 2 * 60 * 1000
 
   /**
    * Session affinity (time-window approximation): DSH exposes no conversation
@@ -109,15 +111,13 @@ export class AgySessionManager {
     return account.email ?? `idx-${account.refresh}`
   }
 
-  /** Resolve a usable access token for the account, refreshing when expired. */
-  private async accessTokenFor(account: ManagedAccount): Promise<OAuthAuthDetails | undefined> {
-    const key = this.accountKey(account)
-    const cached = this.tokenCache.get(key)
-    const now = Date.now()
-    if (cached && !accessTokenExpired({ access: cached.access, expires: cached.expires, refresh: account.refresh })) {
-      return { access: cached.access, expires: cached.expires, refresh: account.refresh }
-    }
-
+  /**
+   * Refresh the account's access token (single-flight per account). A transient
+   * refresh failure keeps the cached token in place (retain-last-good): the old
+   * token stays valid until its own expiry and a later request retries the
+   * refresh. Only `invalid_grant` drops the cache.
+   */
+  private refreshToken(key: string, account: ManagedAccount, cached?: TokenCacheEntry): Promise<OAuthAuthDetails | undefined> {
     const inFlight = this.refreshInFlight.get(key)
     if (inFlight) return inFlight
 
@@ -133,15 +133,32 @@ export class AgySessionManager {
         this.tokenCache.delete(key)
         return undefined
       }
+      // Transient failure: the cached token (when present) remains servable.
       return undefined
     })()
 
     this.refreshInFlight.set(key, refreshing)
-    try {
-      return await refreshing
-    } finally {
-      this.refreshInFlight.delete(key)
+    refreshing.then(
+      () => this.refreshInFlight.delete(key),
+      () => this.refreshInFlight.delete(key),
+    )
+    return refreshing
+  }
+
+  /** Resolve a usable access token for the account, pre-emptively refreshing near expiry. */
+  private async accessTokenFor(account: ManagedAccount): Promise<OAuthAuthDetails | undefined> {
+    const key = this.accountKey(account)
+    const cached = this.tokenCache.get(key)
+    const now = Date.now()
+    if (cached && !accessTokenExpired({ access: cached.access, expires: cached.expires, refresh: account.refresh })) {
+      // Pre-emptive refresh within the skew: serve the still-valid token and
+      // refresh in the background (OMP-style refresh skew).
+      if (cached.expires <= now + AgySessionManager.REFRESH_SKEW_MS) {
+        void this.refreshToken(key, account, cached)
+      }
+      return { access: cached.access, expires: cached.expires, refresh: account.refresh }
     }
+    return this.refreshToken(key, account, cached)
   }
 
   /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -9,13 +9,21 @@ import type { AccountStorageV4, FailureKind, ManagedAccount, OAuthAuthDetails } 
 import { refreshAccessToken } from './oauth/refresh.ts'
 import { accessTokenExpired, formatRefreshParts, parseRefreshParts } from './oauth/auth.ts'
 import type { AccountStore } from './store/accounts.ts'
-import { resolveActiveAccount } from './store/accounts.ts'
 import {
   clearExpiredState,
   decideRotation,
   isCoolingDown,
   pickNextAccountIndex,
+  recordRateLimit,
 } from './runtime/rotation.ts'
+import {
+  familyKeyOf,
+  ingestFamilyQuotas,
+  isFamilyDrained,
+  isQuotaStale,
+  modelFamilyOf,
+  rankPoolCandidates,
+} from './runtime/quota.ts'
 import {
   DEFAULT_FINGERPRINT_DATA,
   generateFingerprint,
@@ -74,9 +82,14 @@ export class AgySessionManager {
   private readonly tokenCache = new Map<string, TokenCacheEntry>()
   /** In-flight refresh promises keyed by account: concurrent requests share one refresh. */
   private readonly refreshInFlight = new Map<string, Promise<OAuthAuthDetails | undefined>>()
+  /** In-flight quota fetches keyed by account: concurrent selections share one fetchAvailableModels call. */
+  private readonly quotaRefreshInFlight = new Map<string, Promise<void>>()
   private readonly failureCounts = new Map<string, number>()
   /** Accounts whose request-time project discovery already failed (no retry per request). */
   private readonly projectRetryFailed = new Set<string>()
+
+  /** Bound for one quota poll so selection never stalls on a hung endpoint. */
+  private static readonly QUOTA_FETCH_TIMEOUT_MS = 3_000
 
   /**
    * Session affinity (time-window approximation): DSH exposes no conversation
@@ -131,30 +144,86 @@ export class AgySessionManager {
     }
   }
 
-  private async pickAccount(storage: AccountStorageV4): Promise<{ account: ManagedAccount; index: number } | undefined> {
+  /**
+   * Refresh stale per-account quota caches (family-scoped, health-based TTL).
+   * Failures leave the account unmeasured: ranking treats it as a fallback
+   * instead of blocking selection on a hung endpoint.
+   */
+  private async refreshQuotaCache(storage: AccountStorageV4): Promise<void> {
+    const now = Date.now()
+    const stale = storage.accounts.filter((account) => account.enabled !== false && isQuotaStale(account, now))
+    if (stale.length === 0) return
+
+    await Promise.all(stale.map(async (account) => {
+      const key = this.accountKey(account)
+      if (this.quotaRefreshInFlight.has(key)) return this.quotaRefreshInFlight.get(key)
+      const refresh = (async () => {
+        try {
+          const auth = await this.accessTokenFor(account)
+          if (!auth) return
+          const { fetchAvailableModels } = await import('./adapter/models.ts')
+          const boundedFetch: typeof fetch = (input, init) => {
+            const timeout = AbortSignal.timeout(AgySessionManager.QUOTA_FETCH_TIMEOUT_MS)
+            const signal = init?.signal ? AbortSignal.any([init.signal, timeout]) : timeout
+            return fetch(input, { ...init, signal })
+          }
+          const discovered = await fetchAvailableModels(auth.access, account.projectId, boundedFetch)
+          const quotas = ingestFamilyQuotas(discovered)
+          const updatedAt = Date.now()
+          await this.store.mutate((s) => {
+            const target = s.accounts.find((candidate) => this.accountKey(candidate) === key)
+            if (target) {
+              if (Object.keys(quotas).length > 0) target.cachedQuota = quotas
+              target.cachedQuotaUpdatedAt = updatedAt
+            }
+          })
+        } catch {
+          // quota stays unmeasured — ranking falls back to rotation order
+        }
+      })()
+      this.quotaRefreshInFlight.set(key, refresh)
+      try {
+        await refresh
+      } finally {
+        this.quotaRefreshInFlight.delete(key)
+      }
+    }))
+  }
+
+  /**
+   * Pick the account for one request: the affinity pin wins while it is fresh,
+   * healthy, and not drained for the requested model; otherwise the pool is
+   * ranked by family-scoped usage (OMP-aligned) and the best candidate wins.
+   */
+  private async pickAccount(storage: AccountStorageV4, model?: string): Promise<{ account: ManagedAccount; index: number } | undefined> {
     const now = Date.now()
     for (const account of storage.accounts) clearExpiredState(account, now)
 
-    let resolved = resolveActiveAccount(storage)
-    if (!resolved) return undefined
+    const family = modelFamilyOf(model)
     // Session affinity (time-window approximation): reuse the last-used account
     // while it is fresh and healthy, so one conversation stays on one account
-    // (upstream prefix cache + sessionId continuity). DSH exposes no
-    // conversation id, so the window is the proxy; rotate clears it.
+    // (upstream prefix cache + sessionId continuity). A drained family or a
+    // cooldown breaks the pin and re-ranks, mirroring OMP's pinned-until-unusable.
     if (this.lastUsed && now - this.lastUsed.at < SESSION_AFFINITY_WINDOW_MS) {
       const last = storage.accounts[this.lastUsed.index]
-      if (last && last.enabled !== false && !isCoolingDown(last, now)) {
-        resolved = { account: last, index: this.lastUsed.index }
+      if (last && last.enabled !== false && !isCoolingDown(last, now) && !isFamilyDrained(last, family)) {
+        return { account: last, index: this.lastUsed.index }
       }
     }
-    // Skip accounts that are cooling down (rate-limit cooldowns).
-    if (isCoolingDown(resolved.account, now)) {
-      const nextIndex = pickNextAccountIndex(storage.accounts, resolved.index, now)
-      if (nextIndex !== resolved.index) {
-        resolved = { account: storage.accounts[nextIndex]!, index: nextIndex }
-      }
+
+    const eligible = storage.accounts
+      .map((account, index) => ({ account, index }))
+      .filter(({ account }) => account.enabled !== false)
+    if (eligible.length === 0) return undefined
+    if (eligible.length === 1) return eligible[0]
+
+    const [picked] = rankPoolCandidates(eligible, model, now, storage.activeIndex)
+    if (!picked) return eligible[0]
+    if (picked.index !== storage.activeIndex) {
+      storage.activeIndex = picked.index
+      await this.store.save(storage)
     }
-    return resolved
+    return { account: picked.account, index: picked.index }
   }
 
   /**
@@ -162,10 +231,15 @@ export class AgySessionManager {
    * missing projectId at request time — the OAuth-time loadCodeAssist may have
    * transiently failed even when the Google account owns a Cloud Code project
    * (mirrors OmniRoute's ensureAntigravityProjectAssigned + persistence).
+   * @param model - requested model id; drives family-scoped quota ranking.
    */
-  async getSession(): Promise<AgyAccountSession | undefined> {
+  async getSession(model?: string): Promise<AgyAccountSession | undefined> {
+    const initial = await this.store.load()
+    await this.refreshQuotaCache(initial)
+    // The quota refresh persists through the store; re-read so the ranking
+    // below sees the fresh cache it just wrote.
     const storage = await this.store.load()
-    const picked = await this.pickAccount(storage)
+    const picked = await this.pickAccount(storage, model)
     if (!picked) return undefined
 
     const auth = await this.accessTokenFor(picked.account)
@@ -212,7 +286,15 @@ export class AgySessionManager {
   async reportFailure(
     kind: FailureKind,
     session: AgyAccountSession,
-    info?: { retryAfterMs?: number; status?: number; rateLimitCategory?: import('./runtime/classify.ts').RateLimitCategory },
+    info?: {
+      retryAfterMs?: number
+      status?: number
+      rateLimitCategory?: import('./runtime/classify.ts').RateLimitCategory
+      /** Server-reported absolute reset time; drives precise cooldowns. */
+      resetTime?: string
+      /** Requested model id; drives family-scoped rate-limit bookkeeping. */
+      model?: string
+    },
   ): Promise<void> {
     const storage = await this.store.load()
     const account = storage.accounts[session.index]
@@ -222,7 +304,12 @@ export class AgySessionManager {
     const consecutive = (this.failureCounts.get(key) ?? 0) + 1
     this.failureCounts.set(key, consecutive)
 
-    const decision = decideRotation(kind, account, consecutive, info?.retryAfterMs, info?.rateLimitCategory)
+    const decision = decideRotation(kind, account, consecutive, info?.retryAfterMs, info?.rateLimitCategory, info?.resetTime)
+
+    if (kind === 'rate-limit' && info?.resetTime) {
+      // Family-scoped bookkeeping of the real reset (display + ranking wall).
+      recordRateLimit(account, familyKeyOf(info?.model), Date.parse(info.resetTime) || Date.now() + 60_000)
+    }
 
     if (decision.action === 'revoke') {
       this.tokenCache.delete(key)

--- a/src/store/accounts.ts
+++ b/src/store/accounts.ts
@@ -6,6 +6,7 @@
 
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { randomUUID } from 'node:crypto'
 import lockfile from 'proper-lockfile'
 import type {
   AccountStorage,
@@ -83,6 +84,19 @@ function encryptAccount(account: ManagedAccount, codec: SecretCodec): ManagedAcc
   return account
 }
 
+export function ensureAccountIds(storage: AccountStorageV4): { storage: AccountStorageV4; mutated: boolean } {
+  let mutated = false
+  const seenIds = new Set<string>()
+  for (const account of storage.accounts) {
+    if (!account.id || seenIds.has(account.id)) {
+      account.id = randomUUID()
+      mutated = true
+    }
+    seenIds.add(account.id)
+  }
+  return { storage, mutated }
+}
+
 export function decryptStorage(storage: AccountStorageV4, codec: SecretCodec): AccountStorageV4 {
   return { ...storage, accounts: storage.accounts.map((a) => decryptAccount(a, codec)) }
 }
@@ -90,7 +104,6 @@ export function decryptStorage(storage: AccountStorageV4, codec: SecretCodec): A
 export function encryptStorage(storage: AccountStorageV4, codec: SecretCodec): AccountStorageV4 {
   return { ...storage, accounts: storage.accounts.map((a) => encryptAccount(a, codec)) }
 }
-
 // ──── Migrations ────────────────────────────────────────────────────────────
 
 export function migrateV1ToV2(v1: AccountStorageV1): AccountStorageV2 {
@@ -162,10 +175,6 @@ export class JsonAccountStore implements AccountStore {
     this.lock = options.lock ?? properFileLock
   }
 
-  /**
-   * Ensure the store document exists before locking: proper-lockfile resolves
-   * the target's realpath and fails with ENOENT when it is absent.
-   */
   private ensureFile(): void {
     if (existsSync(this.file)) return
     mkdirSync(dirname(this.file), { recursive: true })
@@ -174,36 +183,69 @@ export class JsonAccountStore implements AccountStore {
     renameSync(tmp, this.file)
   }
 
-  async load(): Promise<AccountStorageV4> {
+  private readAndMigrateUnlocked(): { storage: AccountStorageV4; mutated: boolean } {
     let text: string
     try {
       text = readFileSync(this.file, 'utf8')
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return { version: CURRENT_STORAGE_VERSION, accounts: [], activeIndex: 0 }
+        return { storage: { version: CURRENT_STORAGE_VERSION, accounts: [], activeIndex: 0 }, mutated: false }
       }
       throw error
     }
     assertOwnerOnly(this.file)
     const raw = JSON.parse(text) as AccountStorage
     const migrated = migrateStorage(raw)
-    return decryptStorage(migrated, this.codec)
+    const decrypted = decryptStorage(migrated, this.codec)
+    return ensureAccountIds(decrypted)
   }
 
-  async save(storage: AccountStorageV4): Promise<void> {
-    const encrypted = encryptStorage(storage, this.codec)
+  private writeUnlocked(storage: AccountStorageV4): void {
+    const encrypted = encryptStorage(ensureAccountIds(storage).storage, this.codec)
     mkdirSync(dirname(this.file), { recursive: true })
     const tmp = `${this.file}.tmp`
     writeFileSync(tmp, JSON.stringify(encrypted, null, 2) + '\n', { mode: 0o600 })
     renameSync(tmp, this.file)
   }
 
+  /**
+   * Materialize and persist generated/repaired UUIDs under the file lock:
+   * re-reads the fresh on-disk state under the lock so concurrent mutations
+   * are never clobbered by a stale pre-lock snapshot.
+   */
+  private async materializeIdsWithLock(): Promise<AccountStorageV4> {
+    this.ensureFile()
+    return this.lock.withLock(this.file, async () => {
+      const { storage, mutated } = this.readAndMigrateUnlocked()
+      if (mutated) {
+        this.writeUnlocked(storage)
+      }
+      return storage
+    })
+  }
+
+  async load(): Promise<AccountStorageV4> {
+    const { storage, mutated } = this.readAndMigrateUnlocked()
+    if (mutated) {
+      // Missing or duplicate IDs detected: atomically materialize and persist under the lock.
+      return this.materializeIdsWithLock()
+    }
+    return storage
+  }
+
+  async save(storage: AccountStorageV4): Promise<void> {
+    this.ensureFile()
+    await this.lock.withLock(this.file, async () => {
+      this.writeUnlocked(storage)
+    })
+  }
+
   async mutate<T>(fn: (storage: AccountStorageV4) => T | Promise<T>): Promise<T> {
     this.ensureFile()
     return this.lock.withLock(this.file, async () => {
-      const storage = await this.load()
+      const { storage } = this.readAndMigrateUnlocked()
       const result = await fn(storage)
-      await this.save(storage)
+      this.writeUnlocked(storage)
       return result
     })
   }
@@ -213,24 +255,32 @@ export class JsonAccountStore implements AccountStore {
 
 export class InMemoryAccountStore implements AccountStore {
   private storage: AccountStorageV4
+  private mutateChain: Promise<unknown> = Promise.resolve()
 
   constructor(initial: AccountStorageV4 = { version: CURRENT_STORAGE_VERSION, accounts: [], activeIndex: 0 }) {
-    this.storage = initial
+    this.storage = ensureAccountIds(initial).storage
   }
 
   async load(): Promise<AccountStorageV4> {
+    const { storage, mutated } = ensureAccountIds(this.storage)
+    if (mutated) this.storage = storage
     return structuredClone(this.storage)
   }
 
   async save(storage: AccountStorageV4): Promise<void> {
-    this.storage = structuredClone(storage)
+    this.storage = structuredClone(ensureAccountIds(storage).storage)
   }
 
   async mutate<T>(fn: (storage: AccountStorageV4) => T | Promise<T>): Promise<T> {
-    const storage = structuredClone(this.storage)
-    const result = await fn(storage)
-    this.storage = storage
-    return result
+    const run = async () => {
+      const storage = structuredClone(ensureAccountIds(this.storage).storage)
+      const result = await fn(storage)
+      this.storage = ensureAccountIds(storage).storage
+      return result
+    }
+    const next = this.mutateChain.then(run, run)
+    this.mutateChain = next
+    return next
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type CooldownReason =
   | 'auth-failure'
   | 'network-error'
   | 'project-error'
+  | 'quota-exhausted'
   | 'validation-required'
 
 /** Per-account quota cache keyed by model id. */
@@ -138,6 +139,56 @@ export interface TokenExchangeFailure {
 }
 
 export type TokenExchangeResult = TokenExchangeSuccess | TokenExchangeFailure
+
+export interface AgyAccountSession {
+  auth: OAuthAuthDetails
+  account: ManagedAccount
+  index: number
+  /** Fingerprint + randomized impersonation headers for this request. */
+  impersonation: {
+    'User-Agent': string
+    'X-Goog-Api-Client': string
+    'Client-Metadata': string
+  }
+}
+
+/** Authentication failure while resolving an account session. */
+export type AgyAuthErrorKind = 'transport' | 'rate-limit' | 'invalid-credential'
+
+/**
+ * Host-independent authentication error. The adapter maps `kind` to the DSH
+ * error protocol without coupling the session or CLI layers to dsh-llm.
+ */
+export class AgyAuthError extends Error {
+  readonly kind: AgyAuthErrorKind
+
+  constructor(kind: AgyAuthErrorKind, message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'AgyAuthError'
+    this.kind = kind
+  }
+}
+
+/** Why an enabled account pool cannot currently serve one model family. */
+export type PoolBlockedKind = 'retryable' | 'quota-exhausted'
+
+/**
+ * Enabled accounts exist, but every candidate is temporarily blocked. Kept
+ * independent of dsh-llm so CLI and web entry points do not gain a host import.
+ */
+export class AgyPoolBlockedError extends Error {
+  readonly kind: PoolBlockedKind
+  readonly blockedUntil: number
+
+  constructor(kind: PoolBlockedKind, blockedUntil: number) {
+    super(kind === 'quota-exhausted'
+      ? 'All agy accounts have exhausted quota for the requested model family.'
+      : 'All agy accounts are temporarily blocked for the requested model family.')
+    this.name = 'AgyPoolBlockedError'
+    this.kind = kind
+    this.blockedUntil = blockedUntil
+  }
+}
 
 /** Classified upstream failure kinds consumed by the rotation state machine. */
 export type FailureKind =

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,10 +39,12 @@ export interface CachedQuota {
 
 /** One account in the pool. `refresh` is the packed `refreshToken|projectId|managedProjectId` string. */
 export interface ManagedAccount {
+  id?: string
   email?: string
   refresh: string
   projectId?: string
   managedProjectId?: string
+  clientId?: string
   addedAt: number
   lastUsed: number
   enabled?: boolean
@@ -127,6 +129,7 @@ export interface TokenExchangeSuccess {
   email?: string
   projectId: string
   tier?: string
+  clientId?: string
 }
 
 export interface TokenExchangeFailure {

--- a/src/web/plugin.ts
+++ b/src/web/plugin.ts
@@ -8,6 +8,7 @@
 
 import type { Context } from '@deepseek-ai/cordis'
 import { createAgyRuntime } from '../plugin-common.ts'
+import { isAgyDisabled } from '../runtime/risk.ts'
 import { createAgyWebRoutes, type WebRoute } from './routes.ts'
 
 export const name = 'dsh-agy-web'
@@ -15,6 +16,10 @@ export const name = 'dsh-agy-web'
 export const inject = ['llm', 'webServer']
 
 export function apply(ctx: Context): void {
+  if (isAgyDisabled()) {
+    ctx.logger.warn('[dsh-agy] disabled by DSH_AGY_DISABLE=1 — skipping /agy registration')
+    return
+  }
   ctx.effect(async () => {
     const webServer = ctx.get('webServer') as
       | { register(route: WebRoute): () => void; host?: string }

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -167,6 +167,7 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
       authMethod: 'oauth',
       email: result.email ?? null,
       projectId: result.projectId || null,
+      clientId: result.clientId || null,
     }, { overwriteExisting: true })
 
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -219,6 +219,19 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
     }
   }
 
+  const handleHealth = async (req: IncomingMessage, res: ServerResponse) => {
+    try {
+      const body = await readJson(req)
+      const indices = Array.isArray(body.indices)
+        ? (body.indices as unknown[]).map((value) => Number(value))
+        : undefined
+      const results = await sessions.checkAccounts(indices)
+      sendJson(res, 200, { results })
+    } catch (error) {
+      sendJson(res, 400, { error: error instanceof Error ? error.message : String(error) })
+    }
+  }
+
   const handleDelete = async (req: IncomingMessage, res: ServerResponse) => {
     try {
       const body = await readJson(req)
@@ -341,6 +354,7 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
     { kind: 'exact', path: '/agy/api/import', handler: handleImport },
     { kind: 'exact', path: '/agy/api/export-all', handler: handleExportAll },
     { kind: 'exact', path: '/agy/api/verify', handler: handleVerify },
+    { kind: 'exact', path: '/agy/api/health', handler: handleHealth },
     { kind: 'exact', path: '/agy/api/delete', handler: handleDelete },
     { kind: 'exact', path: '/agy/api/activate', handler: handleActivate },
     { kind: 'exact', path: '/agy/api/models', handler: handleModels },

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -5,7 +5,7 @@ import { parseAgySse, parseSseDataLine } from '../src/adapter/parse.ts'
 import { fetchAvailableModels, listAgyModels, mergeModelCatalog, resolveAgyModel } from '../src/adapter/models.ts'
 import { AgyAdapter } from '../src/adapter/adapter.ts'
 import type { AgyAccountSession } from '../src/adapter/adapter.ts'
-
+import { AgyAuthError, AgyPoolBlockedError } from '../src/types.ts'
 function textMessage(role: Message['role'], text: string): Message {
   return { id: `m-${Math.random()}`, role, content: [{ type: 'text', text }] } as Message
 }
@@ -595,6 +595,91 @@ describe('AgyAdapter', () => {
     await expect(async () => {
       for await (const _ of adapter.stream(generateOptions())) void _
     }).rejects.toMatchObject({ code: 'RATE_LIMIT', failure: { providerRetryAfterMs: 2000 } })
+  })
+
+  it('converts retryable pool blockage into RATE_LIMIT with a positive integer delay', async () => {
+    const resetAt = Date.now() + 5000
+    const adapter = new AgyAdapter({
+      getSession: async () => {
+        throw new AgyPoolBlockedError('retryable', resetAt)
+      },
+      reportFailure: async () => {},
+    })
+
+    let thrown: unknown
+    try {
+      for await (const _ of adapter.stream(generateOptions())) void _
+    } catch (error) {
+      thrown = error
+    }
+    expect(thrown).toMatchObject({
+      code: 'RATE_LIMIT',
+      failure: { providerRetryAfterMs: expect.any(Number) },
+    })
+    expect(thrown && typeof thrown === 'object' && 'failure' in thrown).toBe(true)
+    if (!thrown || typeof thrown !== 'object' || !('failure' in thrown)) throw new Error('missing failure')
+    const failure = thrown.failure
+    expect(failure && typeof failure === 'object' && 'providerRetryAfterMs' in failure).toBe(true)
+    if (!failure || typeof failure !== 'object' || !('providerRetryAfterMs' in failure)) throw new Error('missing retry delay')
+    const retryMs = failure.providerRetryAfterMs
+    expect(typeof retryMs).toBe('number')
+    if (typeof retryMs !== 'number') throw new Error('retry delay is not numeric')
+    expect(Number.isFinite(retryMs)).toBe(true)
+    expect(Number.isInteger(retryMs)).toBe(true)
+    expect(retryMs).toBeGreaterThan(0)
+  })
+
+  it('maps structured auth failures to the matching host error code', async () => {
+    const cases = [
+      ['transport', 'TRANSPORT'],
+      ['rate-limit', 'RATE_LIMIT'],
+      ['invalid-credential', 'INVALID_CREDENTIAL'],
+    ] as const
+
+    for (const [kind, code] of cases) {
+      const adapter = new AgyAdapter({
+        getSession: async () => {
+          throw new AgyAuthError(kind, `auth ${kind}`)
+        },
+        reportFailure: async () => {},
+      })
+      await expect(async () => {
+        for await (const _ of adapter.stream(generateOptions())) void _
+      }).rejects.toMatchObject({ code })
+    }
+  })
+
+  it('listModels falls back for expected availability errors but rethrows unknown failures', async () => {
+    const blocked = new AgyAdapter({
+      getSession: async () => {
+        throw new AgyPoolBlockedError('retryable', Date.now() + 60000)
+      },
+      reportFailure: async () => {},
+    })
+    const models = await blocked.listModels('agy')
+    expect(models.length).toBeGreaterThan(0)
+    expect(models.some((m) => m.id === 'gemini-2.5-flash')).toBe(true)
+
+    const broken = new AgyAdapter({
+      getSession: async () => { throw new Error('store corrupt') },
+      reportFailure: async () => {},
+    })
+    await expect(broken.listModels('agy')).rejects.toThrow('store corrupt')
+  })
+
+  it('converts quota-exhausted pool blockage into terminal QUOTA error', async () => {
+    const resetAt = Date.now() + 86400000
+    const adapter = new AgyAdapter({
+      getSession: async () => {
+        throw new AgyPoolBlockedError('quota-exhausted', resetAt)
+      },
+      reportFailure: async () => {},
+    })
+    await expect(async () => {
+      for await (const _ of adapter.stream(generateOptions())) void _
+    }).rejects.toMatchObject({
+      code: 'QUOTA',
+    })
   })
 })
 

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -19,6 +19,16 @@ import {
 } from '../src/runtime/fingerprint.ts'
 import { deriveAntigravitySessionId, generateAntigravityRequestId, generateAntigravitySessionId } from '../src/runtime/identity.ts'
 import { resolveAntigravityVersion } from '../src/runtime/version.ts'
+import {
+  FAMILY_UNKNOWN,
+  familyKeyOf,
+  ingestFamilyQuotas,
+  isFamilyDrained,
+  isQuotaStale,
+  modelFamilyOf,
+  rankPoolCandidates,
+  requiredDrainFor,
+} from '../src/runtime/quota.ts'
 import type { ManagedAccount } from '../src/types.ts'
 
 function account(): ManagedAccount {
@@ -140,6 +150,35 @@ describe('rotation state machine', () => {
     const acc5 = account()
     const d5 = decideRotation('network-error', acc5, 5)
     expect(d5.backoffMs).toBeGreaterThan(d0.backoffMs)
+  })
+
+  it('cools daily quota until the real reset time (capped at 24h)', () => {
+    const before = Date.now()
+    const acc = account()
+    const decision = decideRotation('rate-limit', acc, 0, undefined, 'quota_exhausted', new Date(before + 2 * 60 * 60 * 1000).toISOString())
+    expect(decision.action).toBe('cool')
+    expect(acc.coolingDownUntil!).toBeGreaterThanOrEqual(before + 2 * 60 * 60 * 1000 - 1000)
+    expect(acc.coolingDownUntil!).toBeLessThan(before + 2 * 60 * 60 * 1000 + 5000)
+
+    const far = account()
+    decideRotation('rate-limit', far, 0, undefined, 'quota_exhausted', new Date(before + 48 * 60 * 60 * 1000).toISOString())
+    expect(far.coolingDownUntil! - before).toBeLessThan(24 * 60 * 60 * 1000 + 5000)
+  })
+
+  it('cools per-minute limits until the real reset (capped at 30min), ignoring past resets', () => {
+    const before = Date.now()
+    const acc = account()
+    decideRotation('rate-limit', acc, 0, undefined, 'rate_limited', new Date(before + 10 * 60 * 1000).toISOString())
+    expect(acc.coolingDownUntil!).toBeGreaterThanOrEqual(before + 10 * 60 * 1000 - 1000)
+    expect(acc.coolingDownUntil!).toBeLessThan(before + 10 * 60 * 1000 + 5000)
+
+    const far = account()
+    decideRotation('rate-limit', far, 0, undefined, 'rate_limited', new Date(before + 2 * 60 * 60 * 1000).toISOString())
+    expect(far.coolingDownUntil! - before).toBeLessThan(30 * 60 * 1000 + 5000)
+
+    const past = account()
+    decideRotation('rate-limit', past, 0, undefined, 'rate_limited', new Date(before - 60 * 1000).toISOString())
+    expect(past.coolingDownUntil! - before).toBe(5 * 60 * 1000)
   })
 
   it('picks the next eligible account round-robin', () => {
@@ -279,5 +318,135 @@ describe('version resolver', () => {
     }) as unknown as (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
     const version = await resolveAntigravityVersion(fetchImpl)
     expect(version).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+})
+
+describe('quota family mapping', () => {
+  it('maps model ids to backend counter families', () => {
+    expect(modelFamilyOf('gemini-3.5-flash')).toBe('google')
+    expect(modelFamilyOf('gemma-3-27b')).toBe('google')
+    expect(modelFamilyOf('claude-sonnet-4-6')).toBe('anthropic')
+    expect(modelFamilyOf('gpt-oss-120b-medium')).toBe('openai')
+    expect(modelFamilyOf('openai/gpt-5.1')).toBe('openai')
+    expect(modelFamilyOf('some-custom-model')).toBeUndefined()
+    expect(modelFamilyOf(undefined)).toBeUndefined()
+    expect(familyKeyOf('some-custom-model')).toBe(FAMILY_UNKNOWN)
+  })
+})
+
+describe('family quota ingestion', () => {
+  it('aggregates per-model quotaInfo into the most-pressured family record', () => {
+    const ingested = ingestFamilyQuotas({
+      models: {
+        'gemini-a': { quotaInfo: { remainingFraction: 0.2, resetTime: '2099-01-01T00:00:00Z' } },
+        'gemini-b': { quotaInfo: { remainingFraction: 0.05, resetTime: '2098-01-01T00:00:00Z' } },
+        'claude-x': { quotaInfo: { remainingFraction: 0.5 } },
+        'weird-1': { quotaInfo: { remainingFraction: 0.9 } },
+        'no-quota-model': {},
+      },
+    })
+    expect(ingested).toEqual({
+      google: { remainingFraction: 0.05, resetTime: '2098-01-01T00:00:00Z', modelCount: 2 },
+      anthropic: { remainingFraction: 0.5, modelCount: 1 },
+      unknown: { remainingFraction: 0.9, modelCount: 1 },
+    })
+  })
+
+  it('keeps family entries separate and drops models without quota info', () => {
+    expect(ingestFamilyQuotas({ models: { 'claude-a': { quotaInfo: { remainingFraction: 0.1 } } } })).toEqual({
+      anthropic: { remainingFraction: 0.1, modelCount: 1 },
+    })
+    expect(ingestFamilyQuotas({})).toEqual({})
+    expect(ingestFamilyQuotas({ models: undefined })).toEqual({})
+  })
+})
+
+describe('family quota helpers', () => {
+  function withQuota(quota: Record<string, { remainingFraction?: number; resetTime?: string }>, updatedAt = Date.now()): ManagedAccount {
+    const acc = account()
+    acc.cachedQuota = quota
+    acc.cachedQuotaUpdatedAt = updatedAt
+    return acc
+  }
+
+  it('detects drained families below the soft threshold, ignoring past resets', () => {
+    const acc = withQuota({ google: { remainingFraction: 0.05 } })
+    expect(isFamilyDrained(acc, 'google')).toBe(true)
+    expect(isFamilyDrained(acc, 'anthropic')).toBe(false)
+    const resetting = withQuota({ google: { remainingFraction: 0.05, resetTime: '2000-01-01T00:00:00Z' } })
+    expect(isFamilyDrained(resetting, 'google')).toBe(false)
+    expect(isFamilyDrained(account())).toBe(false)
+  })
+
+  it('flags stale caches by health-based TTL', () => {
+    expect(isQuotaStale(account())).toBe(true)
+    expect(isQuotaStale(withQuota({ google: { remainingFraction: 0.9 } }))).toBe(false)
+    const stale = withQuota({ google: { remainingFraction: 0.9 } }, Date.now() - 20 * 60 * 1000)
+    expect(isQuotaStale(stale)).toBe(true)
+    const drainedTtl = withQuota({ google: { remainingFraction: 0.05 } }, Date.now() - 2 * 60 * 1000)
+    expect(isQuotaStale(drainedTtl)).toBe(true)
+  })
+
+  it('computes required-drain from headroom and reset proximity', () => {
+    expect(requiredDrainFor(undefined)).toBe(0)
+    expect(requiredDrainFor({ remainingFraction: 0 })).toBe(0)
+    const day = requiredDrainFor({ remainingFraction: 0.5 })
+    expect(day).toBeCloseTo(0.5 / 24, 4)
+    const hour = requiredDrainFor({ remainingFraction: 0.5, resetTime: new Date(Date.now() + 60 * 60 * 1000).toISOString() })
+    expect(hour).toBeCloseTo(0.5 / 1, 2)
+  })
+})
+
+describe('pool candidate ranking', () => {
+  function entry(index: number, quota?: { remainingFraction?: number; resetTime?: string }, extra: Partial<ManagedAccount> = {}) {
+    const acc: ManagedAccount = { email: `a${index}@x`, refresh: `rt-${index}|p`, addedAt: 0, lastUsed: 0 }
+    if (quota) {
+      acc.cachedQuota = { google: quota }
+      acc.cachedQuotaUpdatedAt = Date.now()
+    }
+    return { account: { ...acc, ...extra }, index }
+  }
+
+  it('orders unblocked before hot before unmeasured before blocked, by drain then usage', () => {
+    const twoHours = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString()
+    const entries = [
+      entry(0, { remainingFraction: 0.9, resetTime: twoHours }), // headroom 0.9 → drain 0.45
+      entry(1, { remainingFraction: 0.5, resetTime: twoHours }), // headroom 0.5 → drain 0.25
+      entry(2), // unmeasured
+      entry(3, { remainingFraction: 0.1 }), // hot (used 0.9 ≥ 0.85)
+      entry(4, undefined, { coolingDownUntil: Date.now() + 60_000 }), // blocked
+    ]
+    const ranked = rankPoolCandidates(entries, 'gemini-3.5-flash')
+    expect(ranked.map((c) => c.index)).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it('blocks exhausted families until their reset and sorts blocked by unblock time', () => {
+    const reset = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString()
+    const entries = [
+      entry(0, { remainingFraction: 0, resetTime: reset }),
+      entry(1, undefined, { coolingDownUntil: Date.now() + 60 * 60 * 1000 }),
+      entry(2, undefined, { coolingDownUntil: Date.now() + 30 * 60 * 1000 }),
+    ]
+    const ranked = rankPoolCandidates(entries, 'gemini-3.5-flash')
+    expect(ranked.map((c) => c.index)).toEqual([2, 1, 0])
+    expect(ranked[2]!.blockedUntil).toBeGreaterThan(Date.now() + 2 * 60 * 60 * 1000)
+  })
+
+  it('keeps the rotation-order bias when nobody is measured', () => {
+    const entries = [entry(0), entry(1), entry(2)]
+    const ranked = rankPoolCandidates(entries, undefined, Date.now(), 1)
+    expect(ranked.map((c) => c.index)).toEqual([1, 2, 0])
+  })
+
+  it('ranks per family, so a pressured anthropic family does not affect gemini picks', () => {
+    const anthropic = entry(0)
+    anthropic.account.cachedQuota = { anthropic: { remainingFraction: 0.02 }, google: { remainingFraction: 0.9 } }
+    anthropic.account.cachedQuotaUpdatedAt = Date.now()
+    const googleHeavy = entry(1)
+    googleHeavy.account.cachedQuota = { google: { remainingFraction: 0.3 } }
+    googleHeavy.account.cachedQuotaUpdatedAt = Date.now()
+    const ranked = rankPoolCandidates([anthropic, googleHeavy], 'gemini-3.5-flash')
+    // For gemini: entry 0 has more headroom (0.9) than entry 1 (0.3) → ranked first.
+    expect(ranked.map((c) => c.index)).toEqual([0, 1])
   })
 })

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -13,6 +13,7 @@ import {
   buildFingerprintHeaders,
   generateFingerprint,
   getRandomizedHeaders,
+  getStableHeaders,
   recordFingerprintVersion,
   restoreFingerprint,
   updateFingerprintVersion,
@@ -29,6 +30,7 @@ import {
   rankPoolCandidates,
   requiredDrainFor,
 } from '../src/runtime/quota.ts'
+import { fingerprintMode, isAgyDisabled } from '../src/runtime/risk.ts'
 import type { ManagedAccount } from '../src/types.ts'
 
 function account(): ManagedAccount {
@@ -277,6 +279,32 @@ describe('fingerprint', () => {
     expect(evicted!.length).toBe(5)
     const current = generateFingerprint()
     expect(restoreFingerprint(evicted, current)?.deviceId).toBe(current.deviceId)
+  })
+
+  it('pins deterministic fallback headers for the stable mode', () => {
+    const first = getStableHeaders()
+    const second = getStableHeaders()
+    expect(first).toEqual(second)
+    expect(first['Client-Metadata']).toContain('"ideType"')
+    expect(Object.keys(first).sort()).toEqual(['Client-Metadata', 'User-Agent', 'X-Goog-Api-Client'])
+  })
+})
+
+describe('risk controls', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('reads the kill switch and fingerprint mode from env', () => {
+    vi.stubEnv('DSH_AGY_DISABLE', '1')
+    expect(isAgyDisabled()).toBe(true)
+    vi.stubEnv('DSH_AGY_DISABLE', '')
+    expect(isAgyDisabled()).toBe(false)
+
+    vi.stubEnv('DSH_AGY_FINGERPRINT_MODE', 'stable')
+    expect(fingerprintMode()).toBe('stable')
+    vi.stubEnv('DSH_AGY_FINGERPRINT_MODE', 'dynamic')
+    expect(fingerprintMode()).toBe('dynamic')
+    vi.unstubAllEnvs()
+    expect(fingerprintMode()).toBe('dynamic')
   })
 })
 

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -104,7 +104,7 @@ describe('rotation state machine', () => {
     const acc = account()
     const decision = decideRotation('rate-limit', acc, 0, undefined, 'rate_limited')
     expect(decision.action).toBe('rotate')
-    expect(acc.coolingDownUntil).toBeGreaterThan(Date.now())
+    expect(acc.coolingDownUntil).toBeUndefined()
     expect(decision.backoffMs).toBeGreaterThan(0)
   })
 
@@ -170,17 +170,19 @@ describe('rotation state machine', () => {
   it('cools per-minute limits until the real reset (capped at 30min), ignoring past resets', () => {
     const before = Date.now()
     const acc = account()
-    decideRotation('rate-limit', acc, 0, undefined, 'rate_limited', new Date(before + 10 * 60 * 1000).toISOString())
-    expect(acc.coolingDownUntil!).toBeGreaterThanOrEqual(before + 10 * 60 * 1000 - 1000)
-    expect(acc.coolingDownUntil!).toBeLessThan(before + 10 * 60 * 1000 + 5000)
+    const decision = decideRotation('rate-limit', acc, 0, undefined, 'rate_limited', new Date(before + 10 * 60 * 1000).toISOString())
+    expect(decision.action).toBe('rotate')
+    expect(decision.backoffMs).toBeGreaterThanOrEqual(10 * 60 * 1000 - 1000)
+    expect(decision.backoffMs).toBeLessThan(10 * 60 * 1000 + 5000)
 
     const far = account()
-    decideRotation('rate-limit', far, 0, undefined, 'rate_limited', new Date(before + 2 * 60 * 60 * 1000).toISOString())
-    expect(far.coolingDownUntil! - before).toBeLessThan(30 * 60 * 1000 + 5000)
+    const farDecision = decideRotation('rate-limit', far, 0, undefined, 'rate_limited', new Date(before + 48 * 60 * 1000).toISOString())
+    expect(farDecision.backoffMs).toBeLessThan(30 * 60 * 1000 + 5000)
 
     const past = account()
-    decideRotation('rate-limit', past, 0, undefined, 'rate_limited', new Date(before - 60 * 1000).toISOString())
-    expect(past.coolingDownUntil! - before).toBe(5 * 60 * 1000)
+    const pastDecision = decideRotation('rate-limit', past, 0, undefined, 'rate_limited', new Date(before - 60 * 1000).toISOString())
+    expect(pastDecision.backoffMs).toBeGreaterThanOrEqual(5 * 60 * 1000 - 1000)
+    expect(pastDecision.backoffMs).toBeLessThan(5 * 60 * 1000 + 5000)
   })
 
   it('picks the next eligible account round-robin', () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AgySessionManager, impersonationHeadersFor, SESSION_AFFINITY_WINDOW_MS } from '../src/session.ts'
 import { InMemoryAccountStore } from '../src/store/accounts.ts'
+import { AgyAuthError, AgyPoolBlockedError } from '../src/types.ts'
 import type { ManagedAccount } from '../src/types.ts'
-
 function account(email = 'a@b.c'): ManagedAccount {
   return { email, refresh: `rt-${email}|proj-1`, projectId: 'proj-1', addedAt: 0, lastUsed: 0, enabled: true }
 }
@@ -479,18 +479,22 @@ describe('usage-driven selection', () => {
     expect(after.accounts[0]!.verificationRequired).toBe(false)
   })
 
-  it('hard gates and blocks requests when the requested family is rate-limited on all accounts', async () => {
+  it('hard gates and throws AgyPoolBlockedError when the requested family is rate-limited on all accounts', async () => {
     stubTokenEndpoint()
     const a = account('a@x')
     const b = account('b@x')
-    a.rateLimitResetTimes = { google: Date.now() + 60_000 }
-    b.rateLimitResetTimes = { google: Date.now() + 60_000 }
+    const resetAt = Date.now() + 60_000
+    a.rateLimitResetTimes = { google: resetAt }
+    b.rateLimitResetTimes = { google: resetAt }
     const store = new InMemoryAccountStore(storage([a, b]))
     const sessions = new AgySessionManager({ store })
 
-    // When requested for Gemini (google family), all accounts are blocked -> must return undefined
-    const session = await sessions.getSession('gemini-3.5-flash')
-    expect(session).toBeUndefined()
+    // When requested for Gemini (google family), all accounts are blocked -> throws retryable AgyPoolBlockedError
+    await expect(sessions.getSession('gemini-3.5-flash')).rejects.toMatchObject({
+      name: 'AgyPoolBlockedError',
+      kind: 'retryable',
+      blockedUntil: resetAt,
+    })
   })
 
   it('legacy accounts without clientId refresh via embedded fallback and persist clientId on success', async () => {
@@ -613,8 +617,7 @@ describe('usage-driven selection', () => {
     const store = new InMemoryAccountStore(storage([legacyAccount]))
     const sessions = new AgySessionManager({ store })
 
-    const session = await sessions.getSession()
-    expect(session).toBeUndefined()
+    await expect(sessions.getSession()).rejects.toMatchObject({ name: 'AgyAuthError', kind: 'transport' })
     const after = await store.load()
     // Transient failure must NOT revoke the account!
     expect(after.accounts[0]!.enabled).toBe(true)
@@ -765,6 +768,140 @@ describe('usage-driven selection', () => {
 
     const after = await store.load()
     expect(after.accounts[0]!.clientId).toBe('1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com')
+  })
+
+  it('degrades gracefully when quota cache mutate fails and overlays fresh quota in memory', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return new Response(JSON.stringify({ access_token: 'at-quota-ok', expires_in: 3600 }), { status: 200 })
+      }
+      if (url.includes('fetchAvailableModels')) {
+        return new Response(JSON.stringify({
+          models: {
+            'gemini-3.5-flash': { quotaInfo: { remainingFraction: 0.8, resetTime: '2099-01-01T00:00:00Z' } },
+          },
+        }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    // Both accounts start with stale exhausted quota (remainingFraction: 0)
+    const a = {
+      ...account('a@x'),
+      cachedQuota: { google: { remainingFraction: 0, resetTime: '2099-01-01T00:00:00Z' } },
+      cachedQuotaUpdatedAt: 1, // expired TTL
+    }
+    const b = {
+      ...account('b@x'),
+      cachedQuota: { google: { remainingFraction: 0, resetTime: '2099-01-01T00:00:00Z' } },
+      cachedQuotaUpdatedAt: 1, // expired TTL
+    }
+    const store = new InMemoryAccountStore(storage([a, b]))
+    const originalMutate = store.mutate.bind(store)
+    // Mutate throws an error (e.g. disk write failure)
+    store.mutate = async (fn) => {
+      const storageCopy = await store.load()
+      const isQuotaWrite = await (async () => {
+        try {
+          await fn(storageCopy)
+          return Boolean(storageCopy.accounts[0]?.cachedQuota?.google?.remainingFraction === 0.8)
+        } catch {
+          return false
+        }
+      })()
+      if (isQuotaWrite) {
+        throw new Error('disk locked: quota write failed')
+      }
+      return originalMutate(fn)
+    }
+
+    const sessions = new AgySessionManager({ store })
+    // getSession must NOT throw quota-exhausted — in-memory overlay provides the newly probed 0.8 headroom!
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session).toBeDefined()
+    expect(session!.auth.access).toBe('at-quota-ok')
+  })
+
+  it('throws transport AgyAuthError on transient token endpoint failure', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return new Response('{"error":"internal_server_error"}', { status: 500, statusText: 'Internal Server Error' })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    const store = new InMemoryAccountStore(storage([account('a@x')]))
+    const sessions = new AgySessionManager({ store })
+
+    await expect(sessions.getSession()).rejects.toMatchObject({
+      name: 'AgyAuthError',
+      kind: 'transport',
+    })
+  })
+
+  it('switches to another enabled account within the same request after invalid_grant', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (!url.includes('oauth2.googleapis.com/token')) throw new Error(`unexpected fetch: ${url}`)
+      const refresh = new URLSearchParams(String(init?.body)).get('refresh_token')
+      if (refresh === 'rt-revoked@x') {
+        return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 })
+      }
+      return new Response(JSON.stringify({ access_token: 'healthy-token', expires_in: 3600 }), { status: 200 })
+    }))
+
+    const now = Date.now()
+    const revoked = { ...account('revoked@x'), cachedQuota: { google: { remainingFraction: 0.8 } }, cachedQuotaUpdatedAt: now }
+    const healthy = { ...account('healthy@x'), cachedQuota: { google: { remainingFraction: 0.8 } }, cachedQuotaUpdatedAt: now }
+    const store = new InMemoryAccountStore(storage([revoked, healthy]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session?.account.email).toBe('healthy@x')
+    expect(session?.auth.access).toBe('healthy-token')
+    const after = await store.load()
+    expect(after.accounts[0]).toMatchObject({ enabled: false, verificationRequired: true })
+    expect(after.accounts[1]?.enabled).toBe(true)
+  })
+
+  it('classifies invalid_client as a permanent credential error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: 'invalid_client' }),
+      { status: 400, statusText: 'Bad Request' },
+    )))
+    const sessions = new AgySessionManager({
+      store: new InMemoryAccountStore(storage([account('invalid@x')])),
+    })
+
+    await expect(sessions.getSession()).rejects.toMatchObject({
+      name: 'AgyAuthError',
+      kind: 'invalid-credential',
+    } satisfies Partial<AgyAuthError>)
+  })
+
+  it('throws quota-exhausted AgyPoolBlockedError when all accounts are quota-exhausted', async () => {
+    stubTokenEndpoint()
+    const resetAt = Date.now() + 12 * 60 * 60 * 1000
+    const a = {
+      ...account('a@x'),
+      coolingDownUntil: resetAt,
+      cooldownReason: 'quota-exhausted' as const,
+    }
+    const b = {
+      ...account('b@x'),
+      cachedQuota: { google: { remainingFraction: 0, resetTime: new Date(resetAt).toISOString() } },
+      cachedQuotaUpdatedAt: Date.now(),
+    }
+    const store = new InMemoryAccountStore(storage([a, b]))
+    const sessions = new AgySessionManager({ store })
+
+    await expect(sessions.getSession('gemini-3.5-flash')).rejects.toMatchObject({
+      name: 'AgyPoolBlockedError',
+      kind: 'quota-exhausted',
+      blockedUntil: resetAt,
+    })
   })
 })
 

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -364,6 +364,65 @@ describe('usage-driven selection', () => {
     // Precise cooldown from the reported reset (capped at 30min), not the fixed 5min window.
     expect(failed.coolingDownUntil).toBeGreaterThan(Date.now() + 29 * 60 * 1000)
   })
+
+  it('stable fingerprint mode pins one identity: no regeneration on repeated rate-limits', async () => {
+    vi.stubEnv('DSH_AGY_FINGERPRINT_MODE', 'stable')
+    stubTokenEndpoint()
+    const store = new InMemoryAccountStore(storage([account('a@x')]))
+    const sessions = new AgySessionManager({ store })
+
+    let session = await sessions.getSession()
+    await sessions.reportFailure('rate-limit', session!)
+    const first = (await store.load()).accounts[0]!.fingerprint!
+    session = await sessions.getSession()
+    await sessions.reportFailure('rate-limit', session!)
+    const after = await store.load()
+    expect(after.accounts[0]!.fingerprint!.deviceId).toBe(first.deviceId)
+    expect(after.accounts[0]!.fingerprintHistory).toHaveLength(1)
+    vi.unstubAllEnvs()
+  })
+
+  it('stable fingerprint mode serves deterministic fallback headers without a fingerprint', () => {
+    vi.stubEnv('DSH_AGY_FINGERPRINT_MODE', 'stable')
+    const first = impersonationHeadersFor(account('a@x'))
+    const second = impersonationHeadersFor(account('a@x'))
+    expect(first).toEqual(second)
+    expect(first['Client-Metadata']).toContain('ANTIGRAVITY')
+    vi.unstubAllEnvs()
+  })
+
+  it('health-check probes enabled accounts in batch and re-enables live ones', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return new Response(JSON.stringify({ access_token: 'at', expires_in: 3600 }), { status: 200 })
+      }
+      if (url.includes('userinfo')) {
+        return new Response(JSON.stringify({ email: 'probed@x' }), { status: 200 })
+      }
+      if (url.includes('fetchAvailableModels')) {
+        return new Response(JSON.stringify({ models: {} }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+    const disabled = { ...account('a@x'), enabled: false, verificationRequired: true }
+    const store = new InMemoryAccountStore(storage([disabled, account('b@x')]))
+    const reports: Array<Array<{ index: number; ok: boolean }>> = []
+    const sessions = new AgySessionManager({ store, onHealthReport: (results) => reports.push(results) })
+
+    // Default target: enabled accounts only (the disabled one is skipped).
+    const results = await sessions.checkAccounts()
+    expect(results.map((r) => r.index)).toEqual([1])
+    expect(results[0]!.ok).toBe(true)
+    expect(reports).toHaveLength(1)
+
+    // Explicit indices include disabled accounts; a live credential re-enables them.
+    const withDisabled = await sessions.checkAccounts([0, 1])
+    expect(withDisabled.map((r) => r.index).sort((x, y) => x - y)).toEqual([0, 1])
+    const after = await store.load()
+    expect(after.accounts[0]!.enabled).toBe(true)
+    expect(after.accounts[0]!.verificationRequired).toBe(false)
+  })
 })
 
 describe('verifyAccount', () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -108,11 +108,11 @@ describe('AgySessionManager', () => {
     const store = new InMemoryAccountStore(storage([account()]))
     const sessions = new AgySessionManager({ store })
 
-    let session = await sessions.getSession()
-    await sessions.reportFailure('rate-limit', session!)
+    let session = await sessions.getSession('gemini-3.5-flash')
+    await sessions.reportFailure('rate-limit', session!, { model: 'gemini-3.5-flash' })
     const first = (await store.load()).accounts[0]!.fingerprint!
-    session = await sessions.getSession()
-    await sessions.reportFailure('rate-limit', session!)
+    session = await sessions.getSession('claude-sonnet-4-6')
+    await sessions.reportFailure('rate-limit', session!, { model: 'claude-sonnet-4-6' })
     const second = (await store.load()).accounts[0]!.fingerprint!
     expect(second.deviceId).not.toBe(first.deviceId)
     expect((await store.load()).accounts[0]!.fingerprintHistory).toHaveLength(2)
@@ -316,11 +316,10 @@ describe('usage-driven selection', () => {
       throw new Error(`unexpected fetch: ${url}`)
     }))
 
-    const store = new InMemoryAccountStore(storage([account('a@x')]))
+    const store = new InMemoryAccountStore(storage([account('a@x'), account('b@x')]))
     const sessions = new AgySessionManager({ store })
 
     const session = await sessions.getSession('gemini-3.5-flash')
-    expect(session!.index).toBe(0)
     const after = await store.load()
     expect(after.accounts[0]!.cachedQuota).toEqual({
       google: { remainingFraction: 0.1, resetTime: '2098-01-01T00:00:00Z', modelCount: 2 },
@@ -361,8 +360,8 @@ describe('usage-driven selection', () => {
     const failed = after.accounts[0]!
     expect(failed.rateLimitResetTimes).toHaveProperty('anthropic')
     expect(failed.rateLimitResetTimes!['anthropic']).toBeGreaterThan(Date.now() + 60 * 60 * 1000)
-    // Precise cooldown from the reported reset (capped at 30min), not the fixed 5min window.
-    expect(failed.coolingDownUntil).toBeGreaterThan(Date.now() + 29 * 60 * 1000)
+    // Family-scoped rate limits do not set account-wide coolingDownUntil so other families stay usable
+    expect(failed.coolingDownUntil).toBeUndefined()
   })
 
   it('stable fingerprint mode pins one identity: no regeneration on repeated rate-limits', async () => {
@@ -371,15 +370,71 @@ describe('usage-driven selection', () => {
     const store = new InMemoryAccountStore(storage([account('a@x')]))
     const sessions = new AgySessionManager({ store })
 
-    let session = await sessions.getSession()
-    await sessions.reportFailure('rate-limit', session!)
+    let session = await sessions.getSession('gemini-3.5-flash')
+    await sessions.reportFailure('rate-limit', session!, { model: 'gemini-3.5-flash' })
     const first = (await store.load()).accounts[0]!.fingerprint!
-    session = await sessions.getSession()
-    await sessions.reportFailure('rate-limit', session!)
+    session = await sessions.getSession('claude-sonnet-4-6')
+    await sessions.reportFailure('rate-limit', session!, { model: 'claude-sonnet-4-6' })
     const after = await store.load()
     expect(after.accounts[0]!.fingerprint!.deviceId).toBe(first.deviceId)
     expect(after.accounts[0]!.fingerprintHistory).toHaveLength(1)
     vi.unstubAllEnvs()
+  })
+  it('skips quota refresh for single-account pools', async () => {
+    let called = false
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return new Response(JSON.stringify({ access_token: 'at', expires_in: 3600 }), { status: 200 })
+      }
+      if (url.includes('fetchAvailableModels')) {
+        called = true
+        return new Response(JSON.stringify({ models: {} }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    const store = new InMemoryAccountStore(storage([account('a@x')]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session!.index).toBe(0)
+    expect(called).toBe(false)
+  })
+
+  it('always refreshes with the account-bound clientId even when env overrides change', async () => {
+    let requestedClientId = ''
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        const body = new URLSearchParams(String(init?.body))
+        requestedClientId = body.get('client_id') ?? ''
+        return new Response(JSON.stringify({ access_token: 'at-fresh', expires_in: 3600 }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    vi.stubEnv('AGY_CLIENT_ID', 'custom-new-client-id')
+    const boundAccount = { ...account('bound@x'), clientId: '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com' }
+    const store = new InMemoryAccountStore(storage([boundAccount]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession()
+    expect(session?.auth.access).toBe('at-fresh')
+    expect(requestedClientId).toBe('1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com')
+    vi.unstubAllEnvs()
+  })
+
+  it('family-scoped rate limit on google does not block anthropic requests', async () => {
+    stubTokenEndpoint()
+    const acc = account('single@x')
+    acc.rateLimitResetTimes = { google: Date.now() + 60_000 }
+    const store = new InMemoryAccountStore(storage([acc]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession('claude-sonnet-4-6')
+    expect(session).toBeDefined()
+    expect(session!.index).toBe(0)
   })
 
   it('stable fingerprint mode serves deterministic fallback headers without a fingerprint', () => {
@@ -422,6 +477,294 @@ describe('usage-driven selection', () => {
     const after = await store.load()
     expect(after.accounts[0]!.enabled).toBe(true)
     expect(after.accounts[0]!.verificationRequired).toBe(false)
+  })
+
+  it('hard gates and blocks requests when the requested family is rate-limited on all accounts', async () => {
+    stubTokenEndpoint()
+    const a = account('a@x')
+    const b = account('b@x')
+    a.rateLimitResetTimes = { google: Date.now() + 60_000 }
+    b.rateLimitResetTimes = { google: Date.now() + 60_000 }
+    const store = new InMemoryAccountStore(storage([a, b]))
+    const sessions = new AgySessionManager({ store })
+
+    // When requested for Gemini (google family), all accounts are blocked -> must return undefined
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session).toBeUndefined()
+  })
+
+  it('legacy accounts without clientId refresh via embedded fallback and persist clientId on success', async () => {
+    let requestedClientId = ''
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        const body = new URLSearchParams(String(init?.body))
+        requestedClientId = body.get('client_id') ?? ''
+        return new Response(JSON.stringify({ access_token: 'at-migrated', expires_in: 3600 }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    // Legacy account: clientId is undefined
+    const legacyAccount: ManagedAccount = { ...account('legacy@x'), clientId: undefined }
+    const store = new InMemoryAccountStore(storage([legacyAccount]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession()
+    expect(session?.auth.access).toBe('at-migrated')
+    expect(requestedClientId).toBe('1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com')
+    // Successfully persisted on account!
+    const after = await store.load()
+    expect(after.accounts[0]!.clientId).toBe('1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com')
+  })
+
+  it('circular candidate ordering aligns to true active account when disabled accounts precede it', async () => {
+    stubTokenEndpoint()
+    const disabled = { ...account('d@x'), enabled: false }
+    const a = account('a@x')
+    const b = account('b@x')
+    // Active index is 2 (account b@x), but index 0 is disabled
+    const store = new InMemoryAccountStore(storage([disabled, a, b], 2))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session!.index).toBe(2)
+  })
+
+  it('soft_rate_limit does not block single-account immediate retries', async () => {
+    stubTokenEndpoint()
+    const store = new InMemoryAccountStore(storage([account('single@x')]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session).toBeDefined()
+    // Report soft rate limit (transient 1.5s burst)
+    await sessions.reportFailure('rate-limit', session!, {
+      rateLimitCategory: 'soft_rate_limit',
+      retryAfterMs: 1500,
+      model: 'gemini-3.5-flash',
+    })
+
+    const after = await store.load()
+    // Neither account-wide nor family-wide hard rate limits are recorded
+    expect(after.accounts[0]!.coolingDownUntil).toBeUndefined()
+    expect(after.accounts[0]!.rateLimitResetTimes?.google).toBeUndefined()
+
+    // Immediate retry on the same account still succeeds!
+    const retrySession = await sessions.getSession('gemini-3.5-flash')
+    expect(retrySession).toBeDefined()
+    expect(retrySession!.index).toBe(0)
+  })
+
+  it('handles legacy fallback: embedded invalid_grant + BYO success', async () => {
+    const attemptedClients: string[] = []
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        const body = new URLSearchParams(String(init?.body))
+        const cid = body.get('client_id') ?? ''
+        attemptedClients.push(cid)
+        if (cid === '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com') {
+          // embedded client rejected
+          return new Response(JSON.stringify({ error: 'invalid_grant', error_description: 'Bad token' }), { status: 400 })
+        }
+        if (cid === 'byo-custom-client-id') {
+          // BYO client succeeds
+          return new Response(JSON.stringify({ access_token: 'byo-access-token', expires_in: 3600 }), { status: 200 })
+        }
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    vi.stubEnv('AGY_CLIENT_ID', 'byo-custom-client-id')
+    const legacyAccount: ManagedAccount = { ...account('byo-migrated@x'), clientId: undefined }
+    const store = new InMemoryAccountStore(storage([legacyAccount]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession()
+    expect(session?.auth.access).toBe('byo-access-token')
+    expect(attemptedClients).toEqual([
+      '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com',
+      'byo-custom-client-id',
+    ])
+    const after = await store.load()
+    expect(after.accounts[0]!.clientId).toBe('byo-custom-client-id')
+    expect(after.accounts[0]!.enabled).toBe(true)
+    vi.unstubAllEnvs()
+  })
+
+  it('handles legacy fallback: embedded invalid_grant + BYO network error does not revoke', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        const body = new URLSearchParams(String(init?.body))
+        const cid = body.get('client_id') ?? ''
+        if (cid === '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com') {
+          return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 })
+        }
+        // BYO client has network failure
+        throw new TypeError('fetch failed on BYO endpoint')
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    vi.stubEnv('AGY_CLIENT_ID', 'byo-client')
+    const legacyAccount: ManagedAccount = { ...account('transient@x'), clientId: undefined }
+    const store = new InMemoryAccountStore(storage([legacyAccount]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession()
+    expect(session).toBeUndefined()
+    const after = await store.load()
+    // Transient failure must NOT revoke the account!
+    expect(after.accounts[0]!.enabled).toBe(true)
+    expect(after.accounts[0]!.verificationRequired).toBeFalsy()
+    vi.unstubAllEnvs()
+  })
+
+  it('preserves email-less account identity across project discovery mutation', async () => {
+    stubTokenEndpoint()
+    // Email-less account: key comes from immutable id
+    const accountWithoutEmail: ManagedAccount = {
+      id: 'imm-uuid-1234',
+      email: undefined,
+      refresh: 'raw-refresh-token',
+      projectId: undefined,
+      addedAt: Date.now(),
+      lastUsed: 0,
+      enabled: true,
+    }
+    const store = new InMemoryAccountStore(storage([accountWithoutEmail]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession()
+    expect(session).toBeDefined()
+
+    // Report a rate-limit failure on the session
+    await sessions.reportFailure('rate-limit', session!, { model: 'gemini-3.5-flash', retryAfterMs: 5000 })
+    const after = await store.load()
+    // Successfully updated rateLimitResetTimes for the immutable account!
+    expect(after.accounts[0]!.rateLimitResetTimes?.google).toBeGreaterThan(Date.now())
+  })
+
+  it('all invalid_grant candidates marks account disabled and verificationRequired in store', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return new Response(JSON.stringify({ error: 'invalid_grant', error_description: 'Token revoked' }), { status: 400 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    const acc = account('all-revoked@x')
+    const store = new InMemoryAccountStore(storage([acc]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession()
+    expect(session).toBeUndefined()
+
+    const after = await store.load()
+    expect(after.accounts[0]!.enabled).toBe(false)
+    expect(after.accounts[0]!.verificationRequired).toBe(true)
+    expect(after.accounts[0]!.verificationRequiredReason).toBe('auth-failure')
+  })
+
+  it('project healing updates the correct account by immutable key even if accounts are shifted', async () => {
+    const accA = { ...account('a@x'), id: 'id-a', projectId: 'proj-a' }
+    const accB = { ...account('b@x'), id: 'id-b', projectId: undefined }
+    const accC = { ...account('c@x'), id: 'id-c', projectId: 'proj-c' }
+
+    const store = new InMemoryAccountStore(storage([accA, accB, accC], 1))
+    const sessions = new AgySessionManager({ store })
+
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return new Response(JSON.stringify({ access_token: 'at', expires_in: 3600 }), { status: 200 })
+      }
+      if (url.includes('loadCodeAssist')) {
+        // Concurrently delete accA from store while loadCodeAssist is in-flight
+        await store.mutate((s) => {
+          s.accounts.splice(0, 1) // accA deleted! accB is now index 0, accC is index 1
+        })
+        return new Response(JSON.stringify({ cloudaicompanionProject: 'healed-proj-b' }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session).toBeDefined()
+    expect(session!.account.email).toBe('b@x')
+
+    const after = await store.load()
+    expect(after.accounts).toHaveLength(2) // accB and accC
+    const targetB = after.accounts.find((a) => a.id === 'id-b')
+    expect(targetB?.projectId).toBe('healed-proj-b')
+    const targetC = after.accounts.find((a) => a.id === 'id-c')
+    expect(targetC?.projectId).toBe('proj-c') // accC untouched!
+  })
+
+  it('session affinity preserves account by immutable key when preceding accounts are deleted', async () => {
+    stubTokenEndpoint()
+    const a = { ...account('a@x'), id: 'id-a' }
+    const b = { ...account('b@x'), id: 'id-b' }
+    const c = { ...account('c@x'), id: 'id-c' }
+    const store = new InMemoryAccountStore(storage([a, b, c], 1))
+    const sessions = new AgySessionManager({ store })
+
+    // Pin session to b@x (index 1)
+    const first = await sessions.getSession('gemini-3.5-flash')
+    expect(first!.account.email).toBe('b@x')
+
+    // Concurrently remove a@x (index 0) from store
+    await store.mutate((s) => {
+      s.accounts.splice(0, 1) // b@x is now index 0
+    })
+
+    // Next request within affinity window should STILL resolve to b@x (now at index 0)!
+    const second = await sessions.getSession('gemini-3.5-flash')
+    expect(second).toBeDefined()
+    expect(second!.account.email).toBe('b@x')
+    expect(second!.index).toBe(0)
+  })
+
+  it('client ID persistence failure rejects the promise and does not pollute tokenCache', async () => {
+    let tokenFetchCount = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        tokenFetchCount++
+        return new Response(JSON.stringify({ access_token: 'at-persist-fail', expires_in: 3600 }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    const legacyAccount: ManagedAccount = { ...account('fail-persist@x'), clientId: undefined }
+    const store = new InMemoryAccountStore(storage([legacyAccount]))
+    const originalMutate = store.mutate.bind(store)
+    let shouldFailMutate = true
+    store.mutate = async (fn) => {
+      if (shouldFailMutate) {
+        throw new Error('disk unavailable: write failed')
+      }
+      return originalMutate(fn)
+    }
+
+    const sessions = new AgySessionManager({ store })
+
+    // First request fails and leaves no dirty token cache
+    await expect(sessions.getSession()).rejects.toThrow(/disk unavailable/)
+    expect(tokenFetchCount).toBe(1)
+
+    // Second request: now mutate succeeds -> MUST re-run refresh and persist, not bypass via cache
+    shouldFailMutate = false
+    const session = await sessions.getSession()
+    expect(session).toBeDefined()
+    expect(session!.auth.access).toBe('at-persist-fail')
+    expect(tokenFetchCount).toBe(2)
+
+    const after = await store.load()
+    expect(after.accounts[0]!.clientId).toBe('1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com')
   })
 })
 

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -198,6 +198,116 @@ describe('AgySessionManager', () => {
     expect(s3?.auth.access).toBe('at-1')
   })
 
+describe('usage-driven selection', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  function quotaAccount(email: string, quota: Record<string, { remainingFraction?: number; resetTime?: string }>): ManagedAccount {
+    return {
+      ...account(email),
+      cachedQuota: quota,
+      cachedQuotaUpdatedAt: Date.now(),
+    }
+  }
+
+  it('ranks the requested family and picks the account with expiring headroom', async () => {
+    stubTokenEndpoint()
+    const store = new InMemoryAccountStore(storage([
+      quotaAccount('a@x', { google: { remainingFraction: 0.9 } }),
+      quotaAccount('b@x', { google: { remainingFraction: 0.2 } }),
+    ], 1))
+    const sessions = new AgySessionManager({ store })
+
+    // a holds the headroom that would expire unused → ranked first for gemini,
+    // re-balancing away from the active account (b).
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session!.index).toBe(0)
+    expect((await store.load()).activeIndex).toBe(0)
+  })
+
+  it('breaks the affinity pin when the pinned account family is drained', async () => {
+    stubTokenEndpoint()
+    const store = new InMemoryAccountStore(storage([
+      quotaAccount('a@x', { google: { remainingFraction: 0.5 } }),
+      quotaAccount('b@x', { google: { remainingFraction: 0.8 } }),
+    ], 0))
+    const sessions = new AgySessionManager({ store })
+
+    const first = await sessions.getSession('gemini-3.5-flash')
+    expect(first!.index).toBe(1) // b holds more headroom → picked and pinned
+    // b's google family drops below the soft threshold.
+    await store.mutate((s) => { s.accounts[1]!.cachedQuota!.google!.remainingFraction = 0.05 })
+    const second = await sessions.getSession('gemini-3.5-flash')
+    expect(second!.index).toBe(0)
+  })
+
+  it('ingests fresh family quotas from fetchAvailableModels when the cache is stale', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return new Response(JSON.stringify({ access_token: 'at', expires_in: 3600 }), { status: 200 })
+      }
+      if (url.includes('fetchAvailableModels')) {
+        return new Response(JSON.stringify({
+          models: {
+            'gemini-3.5-flash': { quotaInfo: { remainingFraction: 0.4, resetTime: '2099-01-01T00:00:00Z' } },
+            'gemini-3.5-pro': { quotaInfo: { remainingFraction: 0.1, resetTime: '2098-01-01T00:00:00Z' } },
+            'claude-sonnet-4-6': { quotaInfo: { remainingFraction: 0.6 } },
+          },
+        }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    const store = new InMemoryAccountStore(storage([account('a@x')]))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session!.index).toBe(0)
+    const after = await store.load()
+    expect(after.accounts[0]!.cachedQuota).toEqual({
+      google: { remainingFraction: 0.1, resetTime: '2098-01-01T00:00:00Z', modelCount: 2 },
+      anthropic: { remainingFraction: 0.6, modelCount: 1 },
+    })
+    expect(after.accounts[0]!.cachedQuotaUpdatedAt).toBeGreaterThan(0)
+  })
+
+  it('keeps selection on rotation order when the quota fetch fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return new Response(JSON.stringify({ access_token: 'at', expires_in: 3600 }), { status: 200 })
+      }
+      if (url.includes('fetchAvailableModels')) {
+        throw new TypeError('fetch failed')
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+
+    const store = new InMemoryAccountStore(storage([account('a@x'), account('b@x')], 1))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession('gemini-3.5-flash')
+    expect(session!.index).toBe(1)
+    expect((await store.load()).accounts[0]!.cachedQuota).toBeUndefined()
+  })
+
+  it('records the family-scoped reset from a rate-limit failure', async () => {
+    stubTokenEndpoint()
+    const store = new InMemoryAccountStore(storage([account('a@x'), account('b@x')], 0))
+    const sessions = new AgySessionManager({ store })
+
+    const session = await sessions.getSession('claude-sonnet-4-6')
+    const reset = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString()
+    await sessions.reportFailure('rate-limit', session!, { resetTime: reset, model: 'claude-sonnet-4-6' })
+    const after = await store.load()
+    const failed = after.accounts[0]!
+    expect(failed.rateLimitResetTimes).toHaveProperty('anthropic')
+    expect(failed.rateLimitResetTimes!['anthropic']).toBeGreaterThan(Date.now() + 60 * 60 * 1000)
+    // Precise cooldown from the reported reset (capped at 30min), not the fixed 5min window.
+    expect(failed.coolingDownUntil).toBeGreaterThan(Date.now() + 29 * 60 * 1000)
+  })
+})
+
 describe('verifyAccount', () => {
   afterEach(() => vi.unstubAllGlobals())
 

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -198,6 +198,64 @@ describe('AgySessionManager', () => {
     expect(s3?.auth.access).toBe('at-1')
   })
 
+  it('pre-emptively refreshes within the skew and serves the cached token meanwhile', async () => {
+    let refreshCalls = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        refreshCalls++
+        await new Promise((r) => setTimeout(r, 50)) // slow endpoint: proves no blocking
+        return new Response(JSON.stringify({ access_token: 'at-' + refreshCalls, expires_in: 3600 }), { status: 200 })
+      }
+      if (url.includes('fetchAvailableModels')) {
+        return new Response(JSON.stringify({ models: {} }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+    const store = new InMemoryAccountStore(storage([account('a@b.c')]))
+    const sessions = new AgySessionManager({ store })
+
+    const first = await sessions.getSession()
+    expect(first!.auth.access).toBe('at-1')
+
+    // 100s before expiry: still valid, but inside the 120s refresh skew.
+    vi.setSystemTime(Date.now() + 3500 * 1000)
+    const second = await sessions.getSession()
+    expect(second!.auth.access).toBe('at-1') // served from cache while the background refresh runs
+    await vi.waitFor(() => expect(refreshCalls).toBe(2))
+    await new Promise((r) => setTimeout(r, 80)) // let the slowed background refresh finish
+    const third = await sessions.getSession()
+    expect(third!.auth.access).toBe('at-2')
+    vi.useRealTimers()
+  })
+
+  it('retains the last good token when a pre-emptive refresh fails', async () => {
+    let failRefresh = false
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('oauth2.googleapis.com/token')) {
+        if (failRefresh) throw new TypeError('fetch failed')
+        return new Response(JSON.stringify({ access_token: 'at-1', expires_in: 3600 }), { status: 200 })
+      }
+      if (url.includes('fetchAvailableModels')) {
+        return new Response(JSON.stringify({ models: {} }), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }))
+    const store = new InMemoryAccountStore(storage([account('a@b.c')]))
+    const sessions = new AgySessionManager({ store })
+
+    const first = await sessions.getSession()
+    expect(first!.auth.access).toBe('at-1')
+
+    failRefresh = true
+    vi.setSystemTime(Date.now() + 3500 * 1000)
+    const second = await sessions.getSession()
+    // The background refresh failed, but the still-valid token stays servable.
+    expect(second!.auth.access).toBe('at-1')
+    vi.useRealTimers()
+  })
+
 describe('usage-driven selection', () => {
   afterEach(() => vi.unstubAllGlobals())
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -177,8 +177,68 @@ describe('in-memory store', () => {
     expect(deduplicateAccountsByEmail(loaded.accounts)).toHaveLength(1)
     expect(resolveActiveAccount(loaded)?.account.email).toBe('a@b.c')
   })
-})
 
+  it('materializes missing UUIDs and persists them across loads', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dsh-agy-'))
+    const file = join(dir, 'agy-accounts.json')
+    // Write raw legacy json without IDs
+    writeFileSync(file, JSON.stringify({
+      version: CURRENT_STORAGE_VERSION,
+      activeIndex: 0,
+      accounts: [
+        { email: 'legacy@x', refresh: 'rt-1', addedAt: 1, lastUsed: 1 },
+      ],
+    }, null, 2) + '\n')
+
+    const store = new JsonAccountStore({ file, codec, lock: noopFileLock })
+    const firstLoad = await store.load()
+    expect(firstLoad.accounts[0]?.id).toBeDefined()
+    const id1 = firstLoad.accounts[0]!.id
+
+    // Second load from fresh store instance must return the EXACT same materialized ID
+    const store2 = new JsonAccountStore({ file, codec, lock: noopFileLock })
+    const secondLoad = await store2.load()
+    expect(secondLoad.accounts[0]?.id).toBe(id1)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('deduplicates duplicate IDs in stored JSON', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dsh-agy-'))
+    const file = join(dir, 'agy-accounts.json')
+    // Write json with identical duplicate IDs
+    writeFileSync(file, JSON.stringify({
+      version: CURRENT_STORAGE_VERSION,
+      activeIndex: 0,
+      accounts: [
+        { id: 'duplicate-id-1', email: 'a@x', refresh: 'rt-a', addedAt: 1, lastUsed: 1 },
+        { id: 'duplicate-id-1', email: 'b@x', refresh: 'rt-b', addedAt: 1, lastUsed: 1 },
+      ],
+    }, null, 2) + '\n')
+
+    const store = new JsonAccountStore({ file, codec, lock: noopFileLock })
+    const loaded = await store.load()
+    expect(loaded.accounts[0]!.id).toBe('duplicate-id-1')
+    expect(loaded.accounts[1]!.id).not.toBe('duplicate-id-1')
+    expect(loaded.accounts[1]!.id).toBeDefined()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('serializes concurrent mutate operations without losing updates', async () => {
+    const store = new InMemoryAccountStore()
+    const p1 = store.mutate(async (s) => {
+      await new Promise((r) => setTimeout(r, 20))
+      s.accounts.push(account('p1@x'))
+    })
+    const p2 = store.mutate(async (s) => {
+      await new Promise((r) => setTimeout(r, 10))
+      s.accounts.push(account('p2@x'))
+    })
+    await Promise.all([p1, p2])
+    const loaded = await store.load()
+    expect(loaded.accounts).toHaveLength(2)
+    expect(loaded.accounts.map((a) => a.email).sort()).toEqual(['p1@x', 'p2@x'])
+  })
+})
 describe('pool helpers', () => {
   it('resolves active account with enabled fallback', () => {
     const storage = {

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -188,7 +188,7 @@ describe('in-memory store', () => {
       accounts: [
         { email: 'legacy@x', refresh: 'rt-1', addedAt: 1, lastUsed: 1 },
       ],
-    }, null, 2) + '\n')
+    }, null, 2) + '\n', { mode: 0o600 })
 
     const store = new JsonAccountStore({ file, codec, lock: noopFileLock })
     const firstLoad = await store.load()
@@ -213,7 +213,7 @@ describe('in-memory store', () => {
         { id: 'duplicate-id-1', email: 'a@x', refresh: 'rt-a', addedAt: 1, lastUsed: 1 },
         { id: 'duplicate-id-1', email: 'b@x', refresh: 'rt-b', addedAt: 1, lastUsed: 1 },
       ],
-    }, null, 2) + '\n')
+    }, null, 2) + '\n', { mode: 0o600 })
 
     const store = new JsonAccountStore({ file, codec, lock: noopFileLock })
     const loaded = await store.load()

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -58,6 +58,7 @@ describe('dsh-agy web routes & page rendering', () => {
     expect(paths).toContain('/agy/api/import')
     expect(paths).toContain('/agy/api/export-all')
     expect(paths).toContain('/agy/api/verify')
+    expect(paths).toContain('/agy/api/health')
     expect(paths).toContain('/agy/api/delete')
     expect(paths).toContain('/agy/api/activate')
     expect(paths).toContain('/agy/api/models')


### PR DESCRIPTION
## Summary

This PR brings dsh-agy's multi-account pool up to the maturity of oh-my-pi's AuthStorage/google-antigravity usage strategy, in three self-contained commits:

1. **6aea4b0 usage-driven account selection with family-scoped quotas**
   - New untime/quota module: model→family mapping (gemini→google / claude→anthropic / gpt→openai), etchAvailableModels quota ingestion into per-family records, drained (<15%) and hot-window (≥85% used) guards, and required-drain ranking mirroring AuthStorage (#orderUsageRankedCandidates: blocked last → hot last → measured first → drain desc → used asc).
   - getSession(model) refreshes stale quota caches (3s bounded, single-flight) and ranks candidates per requested family; the 10-minute affinity pin breaks when the pinned account's family is drained. No quota data ⇒ rotation order seeded from activeIndex (0.2.1 behavior preserved).
   - decideRotation now cools to the server-reported esetTime (capped 30min rate / 24h quota, previous fixed windows as fallback); the adapter threads esetTime + requested model through failure reporting, and rate-limit resets are recorded per family.

2. **b02a27 pre-emptive token refresh with retain-last-good**
   - Requests serve the cached token while a background refresh runs inside a 120s skew window (no blocking on the token endpoint); transient refresh failures keep the previous valid token, only invalid_grant drops it.

3. **70fd521 account health checks and risk-control switches**
   - checkAccounts() batch probe (refresh + userinfo; live credentials re-enable disabled accounts) + optional startHealthProbe(interval); surfaced via new CLI dsh-agy health [--interval] and POST /agy/api/health.
   - Risk controls (untime/risk): DSH_AGY_DISABLE=1 kill switch gates both plugin entries and the CLI; DSH_AGY_FINGERPRINT_MODE=stable pins one identity per account (no regeneration, deterministic fallback headers — OMP-style fixed posture, default stays dynamic); AGY_CLIENT_ID/SECRET BYO-client overrides (esolveAgyClientCredentials).

## Tests

- 20+ new unit/session tests (family mapping, ingestion, ranking order, precise cooldowns, skew refresh, retain-last-good, batch health, stable mode, kill switch); full suite passes (143/144).
- CLI bundle verified free of @deepseek-ai runtime imports; 
pm pack --dry-run contents gate passes.

## Docs

README + docs/ARCHITECTURE updated in EN/zh mirrors (same commit), including a risk-controls env table.

Feedback welcome on the ranking parameterization (hot fraction 0.85, drain floor 60s, cooldown caps) — all mirror AuthStorage's constants.