### PR TITLE
fix(session): handle transient auth errors in health/export probes

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -546,24 +546,28 @@ export class AgySessionManager {
     const storage = await this.store.load()
     const account = storage.accounts[index]
     if (!account) return { error: 'account not found' }
-    const auth = await this.accessTokenFor(account)
-    if (!auth) return { error: 'refresh failed (revoked?)' }
-    const { encodeCredentialBlob } = await import('./oauth/blob.ts')
-    const parts = parseRefreshParts(account.refresh)
-    return {
-      blob: encodeCredentialBlob('agy', {
-        access_token: auth.access,
-        refresh_token: parts.refreshToken,
-        expires_in: Math.max(0, Math.round((auth.expires - Date.now()) / 1000)),
-      }),
+    try {
+      const auth = await this.accessTokenFor(account)
+      if (!auth) return { error: 'refresh failed (revoked?)' }
+      const { encodeCredentialBlob } = await import('./oauth/blob.ts')
+      const parts = parseRefreshParts(account.refresh)
+      return {
+        blob: encodeCredentialBlob('agy', {
+          access_token: auth.access,
+          refresh_token: parts.refreshToken,
+          expires_in: Math.max(0, Math.round((auth.expires - Date.now()) / 1000)),
+        }),
+      }
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) }
     }
   }
 
   /** Probe one account: refresh + userinfo; a live credential re-enables the account. */
   private async probeAccount(index: number, account: ManagedAccount): Promise<{ ok: boolean; email?: string; error?: string }> {
-    const auth = await this.accessTokenFor(account)
-    if (!auth) return { ok: false, error: 'refresh failed (revoked?)' }
     try {
+      const auth = await this.accessTokenFor(account)
+      if (!auth) return { ok: false, error: 'refresh failed (revoked?)' }
       const response = await proxiedFetch('https://www.googleapis.com/oauth2/v1/userinfo?alt=json', {
         headers: { Authorization: `Bearer ${auth.access}` },
       })


### PR DESCRIPTION
合后修（follow-up to #5）

**问题**：`1d835f4` 后 `accessTokenFor` 在瞬态失败时 `throw AgyAuthError`，但 `probeAccount`/`exportBlob` 的 `await accessTokenFor` 仍在外层 `try` 之外，导致整批 `checkAccounts`/`exportBlob` 直接抛异常，而非逐账号返回 `{ok:false}`。离线/5xx/429 时复现，CI 因 mock 不覆盖而未暴露。

**修复**：
- `exportBlob` 包一层 `try/catch` 返回 `{error}`
- `probeAccount` 把 `accessTokenFor` 移入已有 `try` 内

**验证**： `pnpm test` 174 passed, `tsc --noEmit` clean, `build` 29 files.

Refs #5