### PR TITLE
feat(proxy): per-account proxy with fail-closed rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ dsh-agy logout         # remove account
 | `dsh-agy health` | `--index <n...>` — check only these accounts (default: all enabled)<br>`--interval <ms>` — repeat on an interval instead of once | Batch health check (refresh + userinfo), re-enables accounts whose credentials are live again |
 | `dsh-agy logout` | `--index <n>` — account index (default: active)<br>`--email <email>` — account email | Remove an account |
 
+### Per-account proxy
+
+Each account can have its own proxy; credentials are encrypted at rest and displayed masked as `protocol//host:port`.
+
+```sh
+dsh-agy login --proxy socks5://user:pass@host:1080
+dsh-agy import --proxy <url> file.json
+dsh-agy proxy set --index 0 --proxy <url>   # set / update
+dsh-agy proxy clear --index 0               # clear (fall back to env)
+dsh-agy proxy test --index 0                # TCP 2s fast-fail probe
+dsh-agy proxy list                          # masked list
+dsh-agy status                              # shows proxy column (masked host:port)
+```
+
+Fallback: with no per-account proxy, requests use `EnvHttpProxyAgent` (`HTTP_PROXY`/`HTTPS_PROXY` with `NO_PROXY` honored). Per-account proxies ignore `NO_PROXY`, are fail-closed (unreachable proxy skips the account without cooldown and clears affinity), and loopback targets (`localhost`/`127.0.0.1`/`::1`) are always forced direct.
+
+Web dashboard (`/agy`): each account card shows an inline Proxy row `[input] [Save][Clear][Test]` with masked `host:port`; writes via `POST /agy/api/proxy`, probes via `POST /agy/api/proxy/test`.
+
 ### Path C: Local Development & Link
 
 ```sh

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,6 +54,7 @@ Dependency direction: `oauth/` and `store/` are leaves (no internal deps); `runt
 | `adapter/translate` | `toBody(generateOptions) -> RequestBody` | DSH messages/tools -> Gemini contents[], thinking carried verbatim | fixture (recorded requests) |
 | `adapter/parse` | `fromSSE(line) -> Chunk[]` | SSE line parsing, candidates[] -> StreamChunk, usage/error events | fixture (recorded responses) |
 | `adapter/models` | `listModels() / resolveModel(id)` | fetchAvailableModels fetch + catalog metadata merge + filter + fallback | fixture |
+| `proxy` | `normalizeProxyUrl(url) / proxyUrlForLogs(url) / isProxyUnreachableError(err) / dispatcherForAsync(url) / isProxyReachable(url) / proxiedFetch(input, init)` | URL normalization (`socks://`→`socks5://`, `socks5h`→`socks5`, default ports, `?family=`), fast-fail 2s TCP (30s healthy / 2s unhealthy cache), dispatcher cache (`ProxyAgent` keepAlive:1, `SocksProxyAgent` lazy via `socks-proxy-agent`), loopback forced direct, fail-closed (skips account without cooldown), encrypted at rest + masked display via `store/accounts` | pure unit + TCP probe stub |
 
 ## 3. Thin Shells (deliberately shallow, no abstraction)
 
@@ -88,6 +89,7 @@ dsh-agy/
 ├── src/
 │   ├── index.ts            # plugin shell
 │   ├── types.ts / invariant.ts
+│   ├── proxy.ts            # per-account proxy (normalize, fast-fail 2s TCP 30s/2s cache, dispatcher cache keepAlive:1, SOCKS lazy, loopback direct, fail-closed, masked storage)
 │   ├── oauth/  store/  runtime/  adapter/  cli/  web/
 └── tests/
     ├── fixtures/           # recorded payloads (sanitized)

--- a/docs/ARCHITECTURE_zh.md
+++ b/docs/ARCHITECTURE_zh.md
@@ -53,6 +53,7 @@
 | `adapter/translate` | `toBody(generateOptions) → RequestBody` | DSH messages/tools → Gemini contents[]，thinking 原样携带 | fixture（录制请求） |
 | `adapter/parse` | `fromSSE(line) → Chunk[]` | SSE 行解析、candidates[] → StreamChunk、usage/错误事件 | fixture（录制响应原文） |
 | `adapter/models` | `listModels() / resolveModel(id)` | fetchAvailableModels 拉取 + 目录元数据合并 + 过滤 + 降级 | fixture |
+| `proxy` | `normalizeProxyUrl(url) / proxyUrlForLogs(url) / isProxyUnreachableError(err) / dispatcherForAsync(url) / isProxyReachable(url) / proxiedFetch(input, init)` | URL 归一化（`socks://`→`socks5://`、`socks5h`→`socks5`、默认端口、`?family=`）、2s TCP fast-fail（健康 30s / 不健康 2s 缓存）、dispatcher 缓存（`ProxyAgent` keepAlive:1、`SocksProxyAgent` 懒加载 via `socks-proxy-agent`）、loopback 强制直连、fail-closed（跳过账号不冷却）、落盘加密 + 脱敏展示（经 `store/accounts`） | 纯单元 + TCP 探测 stub |
 
 ## 3. 薄壳（刻意浅，不抽象）
 
@@ -87,6 +88,7 @@ dsh-agy/
 ├── src/
 │   ├── index.ts            # 插件壳
 │   ├── types.ts / invariant.ts
+│   ├── proxy.ts            # 每账号代理（归一化、2s TCP fast-fail 30s/2s 缓存、dispatcher 缓存 keepAlive:1、SOCKS 懒加载、loopback 直连、fail-closed、脱敏存储）
 │   ├── oauth/  store/  runtime/  adapter/  cli/  web/
 └── tests/
     ├── fixtures/           # 录制 payloads（脱敏）

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -73,6 +73,24 @@ dsh-agy logout         # 删除账号
 | `dsh-agy health` | `--index <n...>` — 只检查指定账号（默认全部启用账号）<br>`--interval <ms>` — 按间隔重复检查 | 批量健康检查（refresh + userinfo），凭据恢复有效的账号自动重新启用 |
 | `dsh-agy logout` | `--index <n>` — 账号索引（默认当前 active）<br>`--email <email>` — 账号邮箱 | 删除账号 |
 
+### 每账号代理（Per-account proxy）
+
+每个账号可独立配置代理；凭据落盘加密，展示时脱敏为 `protocol//host:port`。
+
+```sh
+dsh-agy login --proxy socks5://user:pass@host:1080
+dsh-agy import --proxy <url> file.json
+dsh-agy proxy set --index 0 --proxy <url>   # 设置/更新
+dsh-agy proxy clear --index 0               # 清除（回退到环境变量代理）
+dsh-agy proxy test --index 0                # TCP 2s fast-fail 探测
+dsh-agy proxy list                          # 脱敏列表
+dsh-agy status                              # 展示 proxy 列（脱敏 host:port）
+```
+
+回退：未配置每账号代理时，请求走 `EnvHttpProxyAgent`（`HTTP_PROXY`/`HTTPS_PROXY` 且遵循 `NO_PROXY`）。每账号代理忽略 `NO_PROXY`、fail-closed（代理不可达则跳过该账号、不写冷却并清除亲和），且 loopback 目标（`localhost`/`127.0.0.1`/`::1`）始终强制直连。
+
+Web 仪表盘（`/agy`）：每张账号卡片内联 Proxy 行 `[输入框] [Save][Clear][Test]`，显示脱敏 `host:port`；写入走 `POST /agy/api/proxy`，探测走 `POST /agy/api/proxy/test`。
+
 ### 路径 C：本地源码开发与调试（Link 模式）
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "proper-lockfile": "^4.1.2",
     "undici": "^7.29.0"
   },
+  "optionalDependencies": {
+    "socks-proxy-agent": "^8.0.5"
+  },
   "devDependencies": {
     "@types/node": "^24.0.0",
     "@types/proper-lockfile": "^4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,10 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.7(@types/node@24.13.3)(tsx@4.23.12)
+    optionalDependencies:
+      socks-proxy-agent:
+        specifier: ^8.0.5
+        version: 8.0.5
 
 packages:
 
@@ -684,6 +688,10 @@ packages:
   '@yuku-toolchain/types@0.8.5':
     resolution: {integrity: sha512-ELNzrhwfi9+VCTaj6QcLCb5MlUK6pmVqPqH8bBmer1FTHvgEITnpwB73L/Wx5KKPPVWAokfeeU9V2rJy/9kMlg==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
@@ -784,6 +792,10 @@ packages:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
 
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -870,6 +882,18 @@ packages:
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1448,6 +1472,9 @@ snapshots:
 
   '@yuku-toolchain/types@0.8.5': {}
 
+  agent-base@7.1.4:
+    optional: true
+
   ansis@4.3.1: {}
 
   assertion-error@2.0.1: {}
@@ -1533,6 +1560,9 @@ snapshots:
   hookable@6.1.1: {}
 
   import-without-cache@0.4.0: {}
+
+  ip-address@10.5.0:
+    optional: true
 
   js-tokens@9.0.1: {}
 
@@ -1643,6 +1673,24 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
+
+  smart-buffer@4.2.0:
+    optional: true
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.5.0
+      smart-buffer: 4.2.0
+    optional: true
 
   source-map-js@1.2.1: {}
 

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -7,7 +7,7 @@
 import { randomUUID } from 'node:crypto'
 import { AGY_ENDPOINT_FALLBACKS, getAgyBootstrapClientMetadata, getAgyBootstrapUserAgent } from '../oauth/constants.ts'
 import { decodeCredentialBlob } from '../oauth/blob.ts'
-import { proxiedFetch } from '../proxy.ts'
+import { normalizeProxyUrl, proxiedFetch } from '../proxy.ts'
 import type { AccountStore } from '../store/accounts.ts'
 import type { ManagedAccount } from '../types.ts'
 
@@ -158,7 +158,7 @@ export async function parseImportSource(source: unknown, kind: 'json' | 'blob'):
 export async function importManySources(
   items: Array<{ source: unknown; kind: 'json' | 'blob' }>,
   store: AccountStore,
-  options: { email?: string; overwriteExisting?: boolean } = {},
+  options: { email?: string; overwriteExisting?: boolean; proxy?: string } = {},
 ): Promise<{ imported: number; replaced: number; errors: string[] }> {
   const result = { imported: 0, replaced: 0, errors: [] as string[] }
   for (const item of items) {
@@ -178,10 +178,18 @@ export async function importManySources(
 export async function upsertImportedAccount(
   store: AccountStore,
   enriched: EnrichedAgyAuth,
-  options: { email?: string; overwriteExisting?: boolean } = {},
+  options: { email?: string; overwriteExisting?: boolean; proxy?: string } = {},
 ): Promise<{ account: ManagedAccount; created: boolean }> {
   const resolvedEmail = options.email || enriched.email
   const refresh = `${enriched.refreshToken}|${enriched.projectId ?? ''}`
+  // Normalize proxy if explicitly provided (empty -> clear -> undefined)
+  let normalizedProxy: string | undefined
+  let proxyProvided = options.proxy !== undefined
+  if (proxyProvided) {
+    const raw = options.proxy ?? ''
+    if (!raw.trim()) normalizedProxy = undefined
+    else normalizedProxy = normalizeProxyUrl(raw)
+  }
 
   return store.mutate((storage) => {
     const existingIndex = resolvedEmail
@@ -197,7 +205,7 @@ export async function upsertImportedAccount(
         )
       }
       const existing = storage.accounts[existingIndex]!
-      storage.accounts[existingIndex] = {
+      const updated: ManagedAccount = {
         ...existing,
         id: existing.id || randomUUID(),
         refresh,
@@ -210,6 +218,11 @@ export async function upsertImportedAccount(
         verificationRequiredAt: undefined,
         verificationRequiredReason: undefined,
       }
+      if (proxyProvided) {
+        if (normalizedProxy) updated.proxy = normalizedProxy
+        else delete (updated as { proxy?: string }).proxy
+      }
+      storage.accounts[existingIndex] = updated
       return { account: storage.accounts[existingIndex]!, created: false }
     }
 
@@ -222,7 +235,9 @@ export async function upsertImportedAccount(
       addedAt: Date.now(),
       lastUsed: Date.now(),
       enabled: true,
+      ...(normalizedProxy ? { proxy: normalizedProxy } : {}),
     }
+    // When proxy was explicitly cleared (empty string) for new account, just omit proxy field
     storage.accounts.push(account)
     if (storage.activeIndex >= storage.accounts.length - 1 && storage.accounts.length === 1) {
       storage.activeIndex = 0

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,11 +15,12 @@ import { encodeCredentialBlob } from '../oauth/blob.ts'
 import { AGY_DEFAULT_REDIRECT_URI } from '../oauth/constants.ts'
 import { createAesGcmCodec, deriveKey, loadMasterKey, resolveDshHome, resolveMasterKeyCodec } from '../store/keyring.ts'
 import type { SecretCodec } from '../store/keyring.ts'
-import { JsonAccountStore } from '../store/accounts.ts'
+import { JsonAccountStore, maskProxyUrl } from '../store/accounts.ts'
 import { AgySessionManager } from '../session.ts'
 import { isAgyDisabled } from '../runtime/risk.ts'
 import { startCallbackServer, openBrowser } from './callback-server.ts'
 import { importManySources, upsertImportedAccount } from './import.ts'
+import { isProxyReachable, normalizeProxyUrl } from '../proxy.ts'
 
 /** Package version, read from the shipped package.json — never hard-coded twice. */
 const { version: PACKAGE_VERSION } = JSON.parse(
@@ -54,6 +55,17 @@ function createReadOnlyStoreOrExit(): JsonAccountStore {
   }
 }
 
+function resolveProxyOption(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined
+  if (!raw.trim()) return ''
+  try {
+    return normalizeProxyUrl(raw)
+  } catch (error) {
+    console.error(`Invalid proxy URL: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+}
+
 async function ask(question: string): Promise<string> {
   const rl = createInterface({ input, output })
   try {
@@ -68,7 +80,10 @@ function isRemoteSession(): boolean {
   return !!(process.env.SSH_CONNECTION || process.env.SSH_CLIENT || process.env.SSH_TTY)
 }
 
-async function loginCommand(options: { headless: boolean; blob: boolean; port: number; project?: string; timeout?: string }) {
+async function loginCommand(options: { headless: boolean; blob: boolean; port: number; project?: string; timeout?: string; proxy?: string }) {
+  const proxyInput = resolveProxyOption(options.proxy)
+  // proxy "" sentinel means clear; normalizeProxyUrl already handled
+  const normalizedProxy = proxyInput === '' ? '' : proxyInput
   const store = createStore()
   const redirectUri = `http://localhost:${options.port}/oauth-callback`
   if (!options.headless && isRemoteSession()) {
@@ -128,6 +143,9 @@ async function loginCommand(options: { headless: boolean; blob: boolean; port: n
   }
 
   if (options.blob) {
+    if (normalizedProxy !== undefined) {
+      console.log('(Note: --proxy is ignored with --blob; proxy is only stored with the account)')
+    }
     const blob = encodeCredentialBlob('agy', {
       access_token: result.access,
       refresh_token: result.refresh.split('|')[0],
@@ -135,6 +153,7 @@ async function loginCommand(options: { headless: boolean; blob: boolean; port: n
     })
     console.log(`\nPaste this blob into the remote dashboard/CLI:\n\n${blob}\n`)
   } else {
+    const proxyForUpsert = normalizedProxy !== undefined ? normalizedProxy : undefined
     const { account, created } = await upsertImportedAccount(store, {
       accessToken: result.access,
       refreshToken: result.refresh.split('|')[0]!,
@@ -144,8 +163,9 @@ async function loginCommand(options: { headless: boolean; blob: boolean; port: n
       email: result.email ?? null,
       projectId: result.projectId || null,
       clientId: result.clientId || null,
-    }, { overwriteExisting: true })
-    console.log(`${created ? 'Added' : 'Updated'} account: ${account.email ?? '(no email)'} (project: ${result.projectId || 'default'})`)
+    }, { overwriteExisting: true, ...(proxyForUpsert !== undefined ? { proxy: proxyForUpsert } : {}) })
+    const masked = maskProxyUrl(account.proxy)
+    console.log(`${created ? 'Added' : 'Updated'} account: ${account.email ?? '(no email)'} (project: ${result.projectId || 'default'})${masked ? ` proxy: ${masked}` : ''}`)
   }
 
   await callback?.close()
@@ -166,7 +186,8 @@ async function statusCommand() {
       : account.verificationRequired ? 'verification-required'
       : account.coolingDownUntil && account.coolingDownUntil > Date.now() ? 'cooling'
       : 'active'
-    console.log(` ${marker} [${index}] ${account.email ?? '(no email)'} — ${state}${account.projectId ? ` (project: ${account.projectId})` : ''}`)
+    const maskedProxy = maskProxyUrl(account.proxy)
+    console.log(` ${marker} [${index}] ${account.email ?? '(no email)'} — ${state}${account.projectId ? ` (project: ${account.projectId})` : ''}${maskedProxy ? ` proxy: ${maskedProxy}` : ''}`)
 
     // Best-effort quota summary via fetchAvailableModels (fresh access token).
     const session = await sessions.getSession().catch(() => undefined)
@@ -194,8 +215,9 @@ async function statusCommand() {
   }
 }
 
-async function importCommand(options: { blob: boolean; files?: string[]; email?: string; overwrite: boolean }) {
+async function importCommand(options: { blob: boolean; files?: string[]; email?: string; overwrite: boolean; proxy?: string }) {
   const store = createStore()
+  const proxyForUpsert = resolveProxyOption(options.proxy)
   let items: Array<{ source: unknown; kind: 'json' | 'blob' }>
   if (options.files && options.files.length > 0) {
     items = options.files.map((file) => {
@@ -206,10 +228,12 @@ async function importCommand(options: { blob: boolean; files?: string[]; email?:
     const pasted = await ask('Paste the agy token JSON (or blob with --blob): ')
     items = [{ source: pasted, kind: options.blob ? 'blob' : 'json' }]
   }
-  const result = await importManySources(items, store, {
+  const importOpts: { email?: string; overwriteExisting?: boolean; proxy?: string } = {
     email: options.email,
     overwriteExisting: options.overwrite,
-  })
+  }
+  if (proxyForUpsert !== undefined) importOpts.proxy = proxyForUpsert
+  const result = await importManySources(items, store, importOpts)
   console.log(`Imported ${result.imported}, replaced ${result.replaced}${result.errors.length > 0 ? `, ${result.errors.length} failed` : ''}`)
   for (const error of result.errors) console.log(`  ! ${error}`)
 }
@@ -315,6 +339,84 @@ async function logoutCommand(options: { index?: string; email?: string }) {
   })
 }
 
+async function proxySetCommand(options: { index: string; proxy: string }) {
+  const idx = Number(options.index)
+  if (!Number.isInteger(idx) || idx < 0) {
+    console.error('Invalid --index (must be >= 0)')
+    process.exit(1)
+  }
+  const raw = options.proxy ?? ''
+  if (!raw.trim()) {
+    console.error('Missing --proxy value')
+    process.exit(1)
+  }
+  let normalized: string
+  try {
+    normalized = normalizeProxyUrl(raw)
+  } catch (error) {
+    console.error(`Invalid proxy URL: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+  const store = createStore()
+  await store.mutate((storage) => {
+    const account = storage.accounts[idx]
+    if (!account) throw new Error(`account not found (index ${idx})`)
+    account.proxy = normalized
+  })
+  console.log(`[${idx}] proxy set to ${maskProxyUrl(normalized)}`)
+}
+
+async function proxyClearCommand(options: { index: string }) {
+  const idx = Number(options.index)
+  if (!Number.isInteger(idx) || idx < 0) {
+    console.error('Invalid --index (must be >= 0)')
+    process.exit(1)
+  }
+  const store = createStore()
+  await store.mutate((storage) => {
+    const account = storage.accounts[idx]
+    if (!account) throw new Error(`account not found (index ${idx})`)
+    delete (account as { proxy?: string }).proxy
+  })
+  console.log(`[${idx}] proxy cleared`)
+}
+
+async function proxyTestCommand(options: { index: string }) {
+  const idx = Number(options.index)
+  if (!Number.isInteger(idx) || idx < 0) {
+    console.error('Invalid --index (must be >= 0)')
+    process.exit(1)
+  }
+  const store = createReadOnlyStoreOrExit()
+  const storage = await store.load()
+  const account = storage.accounts[idx]
+  if (!account) {
+    console.error(`account not found (index ${idx})`)
+    process.exit(1)
+  }
+  if (!account.proxy) {
+    console.log(`[${idx}] no proxy configured`)
+    return
+  }
+  const masked = maskProxyUrl(account.proxy)
+  const reachable = await isProxyReachable(account.proxy)
+  if (reachable) console.log(`[${idx}] ${masked} — ok`)
+  else console.log(`[${idx}] ${masked} — proxy_unreachable`)
+}
+
+async function proxyListCommand() {
+  const store = createReadOnlyStoreOrExit()
+  const storage = await store.load()
+  if (storage.accounts.length === 0) {
+    console.log('No agy accounts.')
+    return
+  }
+  for (const [index, account] of storage.accounts.entries()) {
+    const masked = maskProxyUrl(account.proxy)
+    console.log(` [${index}] ${account.email ?? '(no email)'} — ${masked ?? '(no proxy)'}`)
+  }
+}
+
 export function createProgram(): Command {
   const program = new Command()
   program
@@ -337,6 +439,7 @@ export function createProgram(): Command {
     .option('--port <n>', 'loopback callback port', '51121')
     .option('--project <id>', 'bind the login to a specific project')
     .option('--timeout <ms>', 'callback timeout', '300000')
+    .option('--proxy <url>', 'per-account proxy URL (http/https/socks5); empty to clear')
     .action(async (options) => {
       await loginCommand({ ...options, timeout: options.timeout })
     })
@@ -355,7 +458,8 @@ export function createProgram(): Command {
     .option('--blob', 'the pasted value is a credential blob', false)
     .option('--email <email>', 'account email (skips userinfo verification)')
     .option('--overwrite', 'replace an existing account with the same email', false)
-    .action(async (files: string[] | undefined, options: { blob: boolean; email?: string; overwrite: boolean }) => {
+    .option('--proxy <url>', 'per-account proxy URL (http/https/socks5); empty to clear')
+    .action(async (files: string[] | undefined, options: { blob: boolean; email?: string; overwrite: boolean; proxy?: string }) => {
       await importCommand({ ...options, files })
     })
 
@@ -392,6 +496,36 @@ export function createProgram(): Command {
     .option('--email <email>', 'account email')
     .action(async (options: { index?: string; email?: string }) => {
       await logoutCommand(options)
+    })
+
+  const proxy = program.command('proxy').description('Manage per-account proxies')
+  proxy
+    .command('set')
+    .description('Set proxy for an account')
+    .requiredOption('--index <n>', 'account index')
+    .requiredOption('--proxy <url>', 'proxy URL (http/https/socks5)')
+    .action(async (options: { index: string; proxy: string }) => {
+      await proxySetCommand(options)
+    })
+  proxy
+    .command('clear')
+    .description('Clear proxy for an account')
+    .requiredOption('--index <n>', 'account index')
+    .action(async (options: { index: string }) => {
+      await proxyClearCommand(options)
+    })
+  proxy
+    .command('test')
+    .description('Test proxy reachability for an account (TCP 2s fast-fail)')
+    .requiredOption('--index <n>', 'account index')
+    .action(async (options: { index: string }) => {
+      await proxyTestCommand(options)
+    })
+  proxy
+    .command('list')
+    .description('List accounts with masked proxies')
+    .action(async () => {
+      await proxyListCommand()
     })
 
   return program

--- a/src/oauth/constants.ts
+++ b/src/oauth/constants.ts
@@ -91,7 +91,10 @@ export async function fetchAgyFirstOk(
       const response = await fetchImpl(`${baseEndpoint}${urlPath}`, init)
       if (!AGY_ENDPOINT_SKIP_STATUSES.has(response.status)) return response
       lastSkipped = response
-    } catch {
+    } catch (error) {
+      // Fail-closed: per-account proxy unreachable must not be swallowed and retried on next endpoint
+      const { isProxyUnreachableError } = await import('../proxy.ts')
+      if (isProxyUnreachableError(error)) throw error
       // network error — try the next endpoint
     }
   }

--- a/src/oauth/refresh.ts
+++ b/src/oauth/refresh.ts
@@ -167,14 +167,21 @@ export async function refreshAccessToken(auth: OAuthAuthDetails, options?: { cli
         clientId,
       }
     } catch (error) {
-      transientFailure = {
-        type: 'failed',
-        error: new AgyTokenRefreshError({
-          message: error instanceof Error ? error.message : 'Unknown refresh error',
-          status: 0,
-          statusText: 'Network Error',
-        }),
-      }
+      const raw = error instanceof Error ? error : new Error(String(error))
+      const code = (error as unknown as { code?: string })?.code
+      const errorCode = (error as unknown as { errorCode?: string })?.errorCode
+      const wrapped = new AgyTokenRefreshError({
+        message: raw.message,
+        status: 0,
+        statusText: 'Network Error',
+        code: code ?? errorCode,
+        description: raw.message,
+      })
+      // Preserve original cause/code for isProxyUnreachableError chain
+      ;(wrapped as unknown as { cause?: unknown }).cause = error
+      if (code) (wrapped as unknown as { code?: string }).code = code
+      if (errorCode) (wrapped as unknown as { errorCode?: string }).errorCode = errorCode
+      transientFailure = { type: 'failed', error: wrapped }
     }
   }
 

--- a/src/oauth/refresh.ts
+++ b/src/oauth/refresh.ts
@@ -85,7 +85,7 @@ export type RefreshResult =
  * For legacy accounts without a stored clientId, embedded credentials are tried
  * first with an env-override fallback before treating invalid_grant as fatal.
  */
-export async function refreshAccessToken(auth: OAuthAuthDetails, options?: { clientId?: string }): Promise<RefreshResult> {
+export async function refreshAccessToken(auth: OAuthAuthDetails, options?: { clientId?: string; proxyUrl?: string }): Promise<RefreshResult> {
   const parts = parseRefreshParts(auth.refresh)
   if (!parts.refreshToken) {
     return { type: 'failed', error: new AgyTokenRefreshError({
@@ -119,7 +119,7 @@ export async function refreshAccessToken(auth: OAuthAuthDetails, options?: { cli
           client_id: clientId,
           client_secret: clientSecret,
         }),
-      })
+      }, options?.proxyUrl ? { proxyUrl: options.proxyUrl } : undefined)
 
       if (!response.ok) {
         const errorText = await response.text().catch(() => undefined)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -40,7 +40,7 @@ export function normalizeProxyUrl(proxyUrl: string): string {
   try {
     parsed = new URL(baseRaw)
   } catch {
-    throw new Error(`[proxy] invalid proxy URL: ${proxyUrl}`)
+    throw new Error(`[proxy] invalid proxy URL: ${proxyUrlForLogs(proxyUrl)}`)
   }
   // normalize socks5h -> socks5 (remote DNS, same agent)
   let protocol = parsed.protocol.toLowerCase()

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,20 +1,344 @@
 /**
- * Proxy-aware fetch: respects the standard HTTP_PROXY / HTTPS_PROXY / NO_PROXY
- * environment variables (lowercase variants included) via undici's
- * EnvHttpProxyAgent. Applied per-request through the `dispatcher` option so the
- * plugin never mutates the host process's global dispatcher — DSH's own fetch
- * calls stay untouched.
+ * Proxy-aware fetch: per-account proxy (http/https/socks5) + env fallback.
+ * - account.proxy present => per-account dispatcher (fail-closed, not affected by NO_PROXY)
+ * - otherwise => EnvHttpProxyAgent (honours HTTP_PROXY/HTTPS_PROXY/NO_PROXY)
+ * Applied per-request via dispatcher option so the host's global dispatcher stays untouched.
  */
 
-import { EnvHttpProxyAgent } from 'undici'
+import { EnvHttpProxyAgent, ProxyAgent } from 'undici'
+import { createConnection } from 'node:net'
+import { createRequire } from 'node:module'
 
-const agent = new EnvHttpProxyAgent()
+const envAgent = new EnvHttpProxyAgent()
 
-/** The proxy agent built from the environment (exported for tests). */
-export const proxyAgent = agent
+/** The env proxy agent (exported for tests). */
+export const proxyAgent = envAgent
 
-/** fetch() that routes through the env-configured proxy when one is set. */
-export const proxiedFetch: typeof fetch = (input, init) =>
-  // The Dispatcher type in undici's own types drifts from the undici-types
-  // bundled with @types/node; the runtime interface is stable across versions.
-  fetch(input, { ...init, dispatcher: agent as any })
+// ── Dispatcher cache (bounded by MAX_ACCOUNTS=10, no leak concern) ──
+const dispatcherCache = new Map<string, any>()
+
+// ── Proxy URL normalization ──
+const SUPPORTED = new Set(['http:', 'https:', 'socks5:', 'socks5h:'])
+
+function defaultPort(protocol: string): string {
+  if (protocol === 'https:') return '443'
+  if (protocol === 'socks5:' || protocol === 'socks5h:') return '1080'
+  return '8080'
+}
+
+export function normalizeProxyUrl(proxyUrl: string): string {
+  let raw = proxyUrl.trim()
+  if (!raw) throw new Error('[proxy] empty proxy URL')
+  // alias socks:// -> socks5://
+  if (raw.toLowerCase().startsWith('socks://')) raw = 'socks5://' + raw.slice('socks://'.length)
+  // strip family marker before parse, re-append after
+  const familyMatch = raw.match(/\?family=(ipv4|ipv6)$/)
+  const familySuffix = familyMatch ? familyMatch[0] : ''
+  const baseRaw = familySuffix ? raw.slice(0, -familySuffix.length) : raw
+
+  let parsed: URL
+  try {
+    parsed = new URL(baseRaw)
+  } catch {
+    throw new Error(`[proxy] invalid proxy URL: ${proxyUrl}`)
+  }
+  // normalize socks5h -> socks5 (remote DNS, same agent)
+  let protocol = parsed.protocol.toLowerCase()
+  if (protocol === 'socks5h:') protocol = 'socks5:'
+  if (!SUPPORTED.has(protocol) && protocol !== 'socks5:') {
+    // allow socks5h already normalized
+    if (!SUPPORTED.has(parsed.protocol.toLowerCase())) {
+      throw new Error(`[proxy] unsupported protocol: ${parsed.protocol}`)
+    }
+  }
+  // ensure protocol is one of http/https/socks5
+  if (!['http:', 'https:', 'socks5:'].includes(protocol)) {
+    throw new Error(`[proxy] unsupported protocol: ${parsed.protocol}`)
+  }
+  if (!parsed.hostname) throw new Error('[proxy] missing host')
+
+  let port = parsed.port
+  if (!port) port = defaultPort(protocol)
+  const portNum = Number(port)
+  if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+    throw new Error('[proxy] invalid port')
+  }
+  // Build auth with proper encoding (parsed.username/password are decoded)
+  const auth = parsed.username
+    ? `${encodeURIComponent(parsed.username)}${parsed.password ? `:${encodeURIComponent(parsed.password)}` : ''}@`
+    : ''
+  const normalizedBase = `${protocol}//${auth}${parsed.hostname}:${port}`
+  return familySuffix ? `${normalizedBase}${familySuffix}` : normalizedBase
+}
+
+export function proxyUrlForLogs(proxyUrl: string): string {
+  try {
+    // handle family suffix
+    const fam = proxyUrl.match(/\?family=(ipv4|ipv6)$/)
+    const base = fam ? proxyUrl.slice(0, -fam[0].length) : proxyUrl
+    const u = new URL(base)
+    const port = u.port || defaultPort(u.protocol)
+    return `${u.protocol}//${u.hostname}:${port}`
+  } catch {
+    return proxyUrl
+  }
+}
+
+// ── Proxy unreachable detection (mirrors OmniRoute proxyFetch.ts:30) ──
+const PROXY_UNREACHABLE_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+])
+
+function isLoopbackUrl(url: string | URL): boolean {
+  try {
+    const u = typeof url === 'string' ? new URL(url as string) : (url as URL)
+    const h = u.hostname.toLowerCase()
+    return h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '::ffff:127.0.0.1'
+  } catch {
+    return false
+  }
+}
+
+export function isProxyUnreachableError(err: unknown): boolean {
+  const seen = new Set<unknown>()
+  let cur: unknown = err
+  for (let depth = 0; cur && depth < 5 && !seen.has(cur); depth++) {
+    seen.add(cur)
+    if (cur && typeof cur === 'object') {
+      const code = (cur as { code?: unknown }).code
+      if (typeof code === 'string' && PROXY_UNREACHABLE_CODES.has(code)) return true
+      const errorCode = (cur as { errorCode?: unknown }).errorCode
+      if (errorCode === 'proxy_unreachable' || errorCode === 'PROXY_UNREACHABLE') return true
+      const statusCode = (cur as { statusCode?: unknown }).statusCode
+      if (statusCode === 503) {
+        const m = (cur as { message?: unknown }).message
+        if (typeof m === 'string' && m.includes('Proxy unreachable')) return true
+      }
+      const msg = (cur as { message?: unknown }).message
+      if (typeof msg === 'string') {
+        if (msg.includes('proxy_unreachable') || msg.includes('PROXY_UNREACHABLE')) return true
+        for (const c of PROXY_UNREACHABLE_CODES) {
+          if (msg.includes(c)) return true
+        }
+      }
+    }
+    cur = (cur as { cause?: unknown })?.cause
+    // Also handle AggregateError.errors (undici Happy Eyeballs)
+    if (!cur && (err as { errors?: unknown })?.errors && depth === 0) {
+      const errs = (err as { errors?: unknown[] }).errors
+      if (Array.isArray(errs)) {
+        for (const e of errs) if (isProxyUnreachableError(e)) return true
+      }
+    }
+  }
+  return false
+}
+
+export function tagProxyUnreachable<T>(err: T): T {
+  if (isProxyUnreachableError(err)) {
+    const e = err as unknown as Error & { code?: string; errorCode?: string }
+    e.code = 'PROXY_UNREACHABLE'
+    e.errorCode = 'proxy_unreachable'
+  }
+  return err
+}
+
+// ── Fast-fail TCP reachability (2s, 30s healthy / 2s unhealthy cache) ──
+const FAST_FAIL_TIMEOUT_MS = 2000
+const HEALTHY_TTL_MS = 30_000
+const UNHEALTHY_TTL_MS = 2000
+type HealthEntry = { healthy: boolean; at: number; ttl: number }
+const healthCache = new Map<string, HealthEntry>()
+const healthInflight = new Map<string, Promise<boolean>>()
+
+function tcpCheck(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port }, () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.setTimeout(timeoutMs)
+    socket.on('error', () => resolve(false))
+    socket.on('timeout', () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}
+
+export async function isProxyReachable(proxyUrl: string, timeoutMs = FAST_FAIL_TIMEOUT_MS): Promise<boolean> {
+  const key = normalizeProxyUrl(proxyUrl)
+  const cached = healthCache.get(key)
+  if (cached && Date.now() - cached.at < cached.ttl) return cached.healthy
+  const existing = healthInflight.get(key)
+  if (existing) return existing
+  let url: URL
+  try {
+    const base = key.replace(/\?family=(ipv4|ipv6)$/, '')
+    url = new URL(base)
+  } catch {
+    healthCache.set(key, { healthy: false, at: Date.now(), ttl: UNHEALTHY_TTL_MS })
+    return false
+  }
+  const host = url.hostname.replace(/^\[/, '').replace(/\]$/, '')
+  const port = Number(url.port || defaultPort(url.protocol))
+  const probe = tcpCheck(host, port, timeoutMs).then((healthy) => {
+    healthCache.set(key, { healthy, at: Date.now(), ttl: healthy ? HEALTHY_TTL_MS : UNHEALTHY_TTL_MS })
+    return healthy
+  })
+  healthInflight.set(key, probe)
+  try {
+    return await probe
+  } finally {
+    if (healthInflight.get(key) === probe) healthInflight.delete(key)
+  }
+}
+
+export function _clearProxyHealthCacheForTest(): void {
+  healthCache.clear()
+  healthInflight.clear()
+}
+
+// ── Dispatcher creation (cached) ──
+async function createSocksDispatcher(proxyUrl: string, dispatcherOpts: Record<string, unknown>): Promise<any> {
+  // @ts-ignore — optional dep, only required for socks5
+  const { SocksProxyAgent } = await import('socks-proxy-agent')
+  // socks-proxy-agent is compatible with undici dispatcher interface via fetch
+  return new (SocksProxyAgent as any)(proxyUrl) as any
+}
+
+function createHttpDispatcher(proxyUrl: string, dispatcherOpts: Record<string, unknown>): any {
+  const clean = proxyUrl.replace(/\?family=(ipv4|ipv6)$/, '')
+  return new ProxyAgent({
+    uri: clean,
+    // tunnel all (http+https) via CONNECT, same as OmniRoute
+    proxyTunnel: true,
+    ...dispatcherOpts,
+  } as any)
+}
+
+const DISPATCHER_OPTS = {
+  headersTimeout: 30_000,
+  bodyTimeout: 30_000,
+  connectTimeout: 10_000,
+  keepAliveTimeout: 1,
+  keepAliveMaxTimeout: 1,
+  pipelining: 0,
+} as const
+
+export function dispatcherFor(proxyUrl?: string): any | undefined {
+  if (!proxyUrl) return envAgent as any
+  const normalized = normalizeProxyUrl(proxyUrl)
+  const cached = dispatcherCache.get(normalized)
+  if (cached) return cached
+  const famClean = normalized.replace(/\?family=(ipv4|ipv6)$/, '')
+  let dispatcher: any
+  if (famClean.startsWith('socks5:')) {
+    // SOCKS needs SocksProxyAgent. Try sync require for cached case; otherwise prefer async path (proxiedFetch uses dispatcherForAsync).
+    try {
+      const rq = createRequire(import.meta.url)
+      const mod = rq('socks-proxy-agent') as { SocksProxyAgent?: new (u: string) => unknown }
+      const Cls = mod.SocksProxyAgent
+      if (Cls) {
+        dispatcher = new (Cls as unknown as new (u: string) => unknown)(normalized) as unknown
+      } else {
+        throw new Error('no SocksProxyAgent')
+      }
+    } catch {
+      throw new Error('[proxy] socks dispatcher requires async creation — use dispatcherForAsync or proxiedFetch with proxyUrl')
+    }
+  } else {
+    dispatcher = createHttpDispatcher(normalized, DISPATCHER_OPTS as any)
+  }
+  dispatcherCache.set(normalized, dispatcher)
+  return dispatcher
+}
+
+export async function dispatcherForAsync(proxyUrl?: string): Promise<any | undefined> {
+  if (!proxyUrl) return envAgent as any
+  const normalized = normalizeProxyUrl(proxyUrl)
+  const cached = dispatcherCache.get(normalized)
+  if (cached) return cached
+  const famClean = normalized.replace(/\?family=(ipv4|ipv6)$/, '')
+  let dispatcher: any
+  if (famClean.startsWith('socks5:')) {
+    dispatcher = await createSocksDispatcher(normalized, DISPATCHER_OPTS as any)
+  } else {
+    dispatcher = createHttpDispatcher(normalized, DISPATCHER_OPTS as any)
+  }
+  dispatcherCache.set(normalized, dispatcher)
+  return dispatcher
+}
+
+export function _clearDispatcherCacheForTest(): void {
+  dispatcherCache.clear()
+}
+
+function getTargetUrlString(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === 'string') return input
+  try {
+    if (input instanceof URL) return input.toString()
+    if (typeof (input as Request).url === 'string') return (input as Request).url
+  } catch {
+    // ignore
+  }
+  return ''
+}
+
+/** fetch() that respects per-account proxyUrl (when given) otherwise env. */
+export const proxiedFetch = async (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1] & { proxyUrl?: string },
+  opts?: { proxyUrl?: string },
+): Promise<Response> => {
+  const proxyUrl = (opts as any)?.proxyUrl ?? (init as any)?.proxyUrl
+  // Normalize init without proxyUrl leakage
+  const cleanInit = { ...init } as any
+  if (cleanInit.proxyUrl) delete cleanInit.proxyUrl
+  if (!proxyUrl) {
+    return fetch(input, { ...cleanInit, dispatcher: envAgent as any })
+  }
+  // Loopback bypass: per-account proxy must never intercept OAuth loopback callback (spec 1)
+  const targetStr = getTargetUrlString(input)
+  if (targetStr && isLoopbackUrl(targetStr)) {
+    return fetch(input, cleanInit as RequestInit)
+  }
+  // Fast-fail pre-check (skip for env path)
+  try {
+    const reachable = await isProxyReachable(proxyUrl)
+    if (!reachable) {
+      const err = new Error(`[Proxy Fast-Fail] Proxy unreachable: ${proxyUrlForLogs(proxyUrl)}`) as Error & { code?: string; errorCode?: string; statusCode?: number }
+      err.code = 'PROXY_UNREACHABLE'
+      err.errorCode = 'proxy_unreachable'
+      ;(err as any).statusCode = 503
+      throw err
+    }
+  } catch (e) {
+    if ((e as any)?.errorCode === 'proxy_unreachable') throw e
+    // normalization failure -> throw
+    if (e instanceof Error && e.message.startsWith('[proxy]')) throw e
+  }
+
+  let dispatcher: any
+  try {
+    dispatcher = await dispatcherForAsync(proxyUrl)
+  } catch (e) {
+    throw tagProxyUnreachable(e)
+  }
+  try {
+    return await fetch(input, { ...cleanInit, dispatcher })
+  } catch (err) {
+    // Tag proxy unreachable so caller can classify
+    throw tagProxyUnreachable(err)
+  }
+}
+
+// Keep named export for tests that assert instanceof
+export { envAgent as _envAgentForTest }

--- a/src/runtime/classify.ts
+++ b/src/runtime/classify.ts
@@ -158,6 +158,21 @@ export function classifyFetchError(error: unknown): ClassifiedError {
   if (error instanceof DOMException && error.name === 'AbortError') {
     return { kind: 'network-error', message }
   }
+  // Proxy unreachable is a distinct transport failure (fail-closed, not network-error cooldown)
+  // Check cause chain via isProxyUnreachableError helper without circular import (inline check)
+  const code = (error as { code?: unknown })?.code
+  const cause = (error as { cause?: unknown })?.cause
+  const causeCode = cause && typeof cause === 'object' ? (cause as { code?: unknown }).code : undefined
+  const errorCode = (error as { errorCode?: unknown })?.errorCode
+  if (
+    errorCode === 'proxy_unreachable' ||
+    errorCode === 'PROXY_UNREACHABLE' ||
+    code === 'PROXY_UNREACHABLE' ||
+    causeCode === 'PROXY_UNREACHABLE' ||
+    (typeof message === 'string' && (message.includes('proxy_unreachable') || message.includes('PROXY_UNREACHABLE') || message.includes('Proxy unreachable')))
+  ) {
+    return { kind: 'proxy-unreachable', message }
+  }
   return { kind: 'network-error', message }
 }
 

--- a/src/runtime/classify.ts
+++ b/src/runtime/classify.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FailureKind } from '../types.ts'
+import { isProxyUnreachableError } from '../proxy.ts'
 
 export interface ClassifiedError {
   kind: FailureKind
@@ -158,19 +159,7 @@ export function classifyFetchError(error: unknown): ClassifiedError {
   if (error instanceof DOMException && error.name === 'AbortError') {
     return { kind: 'network-error', message }
   }
-  // Proxy unreachable is a distinct transport failure (fail-closed, not network-error cooldown)
-  // Check cause chain via isProxyUnreachableError helper without circular import (inline check)
-  const code = (error as { code?: unknown })?.code
-  const cause = (error as { cause?: unknown })?.cause
-  const causeCode = cause && typeof cause === 'object' ? (cause as { code?: unknown }).code : undefined
-  const errorCode = (error as { errorCode?: unknown })?.errorCode
-  if (
-    errorCode === 'proxy_unreachable' ||
-    errorCode === 'PROXY_UNREACHABLE' ||
-    code === 'PROXY_UNREACHABLE' ||
-    causeCode === 'PROXY_UNREACHABLE' ||
-    (typeof message === 'string' && (message.includes('proxy_unreachable') || message.includes('PROXY_UNREACHABLE') || message.includes('Proxy unreachable')))
-  ) {
+  if (isProxyUnreachableError(error)) {
     return { kind: 'proxy-unreachable', message }
   }
   return { kind: 'network-error', message }

--- a/src/runtime/rotation.ts
+++ b/src/runtime/rotation.ts
@@ -162,6 +162,11 @@ export function decideRotation(
     case 'transient': {
       return { action: 'retry', backoffMs }
     }
+    case 'proxy-unreachable': {
+      // Per-account proxy dead: fail-closed, skip this account for this request only.
+      // Do NOT write coolingDownUntil / rateLimitResetTimes — next request may retry.
+      return { action: 'rotate', backoffMs: Math.min(backoffMs, 1000) }
+    }
   }
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -40,7 +40,7 @@ import {
 import { deriveAntigravitySessionId } from './runtime/identity.ts'
 import { fingerprintMode } from './runtime/risk.ts'
 import { peekCachedAntigravityVersion, resolveAntigravityVersionBounded } from './runtime/version.ts'
-import { proxiedFetch } from './proxy.ts'
+import { isProxyUnreachableError, proxiedFetch } from './proxy.ts'
 import type { Fingerprint } from './types.ts'
 
 export interface SessionManagerOptions {
@@ -151,7 +151,7 @@ export class AgySessionManager {
     const refreshing = (async (): Promise<OAuthAuthDetails | undefined> => {
       const result = await refreshAccessToken(
         { access: cached?.access ?? '', expires: cached?.expires ?? 0, refresh: account.refresh },
-        { clientId: account.clientId },
+        { clientId: account.clientId, proxyUrl: account.proxy },
       )
       if (result.type === 'success') {
         if (!account.clientId && result.clientId) {
@@ -169,6 +169,9 @@ export class AgySessionManager {
       if (result.type === 'failed') {
         if (cached && !accessTokenExpired({ access: cached.access, expires: cached.expires, refresh: account.refresh })) {
           return { access: cached.access, expires: cached.expires, refresh: account.refresh }
+        }
+        if (isProxyUnreachableError(result.error)) {
+          throw new AgyAuthError('transport', 'proxy_unreachable', { cause: result.error })
         }
         const kind = result.error.status === 429
           ? 'rate-limit'
@@ -244,7 +247,15 @@ export class AgySessionManager {
             const signal = init?.signal ? AbortSignal.any([init.signal, timeout]) : timeout
             return fetch(input, { ...init, signal })
           }
-          const discovered = await fetchAvailableModels(auth.access, account.projectId, boundedFetch)
+          const discovered = await fetchAvailableModels(auth.access, account.projectId, (input, init) => {
+            const timeout = AbortSignal.timeout(AgySessionManager.QUOTA_FETCH_TIMEOUT_MS)
+            const signal = init?.signal ? AbortSignal.any([init.signal, timeout]) : timeout
+            // Explicit threading of per-account proxy (fail-closed). Use proxiedFetch when proxy is set.
+            if (account.proxy) {
+              return proxiedFetch(input, { ...init, signal }, { proxyUrl: account.proxy })
+            }
+            return fetch(input, { ...init, signal })
+          })
           const quotas = ingestFamilyQuotas(discovered)
           return { key, quotas, updatedAt: Date.now() }
         } catch {
@@ -361,7 +372,33 @@ export class AgySessionManager {
       }
       const picked = await this.pickAccount(storage, model)
       if (!picked) return undefined
-      const auth = await this.accessTokenFor(picked.account)
+      let auth: OAuthAuthDetails | undefined
+      try {
+        auth = await this.accessTokenFor(picked.account)
+      } catch (error) {
+        if (error instanceof AgyAuthError && error.kind === 'transport' && isProxyUnreachableError(error)) {
+          // Fail-closed for per-account proxy: skip this account this request, do not write cooldown.
+          this.lastUsed = null
+          // Rotate activeIndex away from the dead proxy account for next pick
+          const deadIndex = storage.accounts.findIndex((a) => this.accountKey(a) === this.accountKey(picked.account))
+          if (deadIndex !== -1) {
+            const next = pickNextAccountIndex(storage.accounts, deadIndex, Date.now())
+            if (next !== storage.activeIndex) {
+              storage.activeIndex = next
+              await this.store.mutate((s) => { s.activeIndex = next }).catch(() => {})
+            }
+          }
+          storage = await this.store.load()
+          continue
+        }
+        // Also handle direct isProxyUnreachableError without AgyAuthError wrapper
+        if (isProxyUnreachableError(error)) {
+          this.lastUsed = null
+          storage = await this.store.load()
+          continue
+        }
+        throw error
+      }
       if (!auth) {
         // The selected credential was revoked and disabled by accessTokenFor.
         // Re-read and select another enabled account within this same request.
@@ -570,7 +607,7 @@ export class AgySessionManager {
       if (!auth) return { ok: false, error: 'refresh failed (revoked?)' }
       const response = await proxiedFetch('https://www.googleapis.com/oauth2/v1/userinfo?alt=json', {
         headers: { Authorization: `Bearer ${auth.access}` },
-      })
+      }, account.proxy ? { proxyUrl: account.proxy } : undefined)
       if (!response.ok) return { ok: false, error: `userinfo ${response.status}` }
       const info = (await response.json()) as { email?: string }
       // Credentials are live again — clear any auth-failure disable so the

--- a/src/session.ts
+++ b/src/session.ts
@@ -363,6 +363,7 @@ export class AgySessionManager {
   async getSession(model?: string): Promise<AgyAccountSession | undefined> {
     let storage = await this.store.load()
     const maxAttempts = storage.accounts.filter((account) => account.enabled !== false).length
+    let proxyUnreachableCount = 0
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const eligible = storage.accounts.filter((account) => account.enabled !== false)
@@ -378,6 +379,7 @@ export class AgySessionManager {
       } catch (error) {
         if (error instanceof AgyAuthError && error.kind === 'transport' && isProxyUnreachableError(error)) {
           // Fail-closed for per-account proxy: skip this account this request, do not write cooldown.
+          proxyUnreachableCount++
           this.lastUsed = null
           // Rotate activeIndex away from the dead proxy account for next pick
           const deadIndex = storage.accounts.findIndex((a) => this.accountKey(a) === this.accountKey(picked.account))
@@ -393,6 +395,7 @@ export class AgySessionManager {
         }
         // Also handle direct isProxyUnreachableError without AgyAuthError wrapper
         if (isProxyUnreachableError(error)) {
+          proxyUnreachableCount++
           this.lastUsed = null
           storage = await this.store.load()
           continue
@@ -444,6 +447,9 @@ export class AgySessionManager {
       }
     }
 
+    if (proxyUnreachableCount === maxAttempts && maxAttempts > 0) {
+      throw new AgyAuthError('transport', 'proxy_unreachable')
+    }
     return undefined
   }
 

--- a/src/store/accounts.ts
+++ b/src/store/accounts.ts
@@ -68,20 +68,46 @@ function isEncrypted(value: string): boolean {
   return value.startsWith(ENC_PREFIX)
 }
 
-/** Decrypt one account's refresh field when encrypted; plaintext passes through (legacy). */
+/** Decrypt one account's refresh/proxy fields when encrypted; plaintext passes through (legacy). */
 function decryptAccount(account: ManagedAccount, codec: SecretCodec): ManagedAccount {
-  if (isEncrypted(account.refresh)) {
-    return { ...account, refresh: codec.decrypt(account.refresh) }
+  let out = account
+  if (isEncrypted(out.refresh)) {
+    out = { ...out, refresh: codec.decrypt(out.refresh) }
   }
-  return account
+  if (out.proxy && isEncrypted(out.proxy)) {
+    out = { ...out, proxy: codec.decrypt(out.proxy) }
+  }
+  return out
 }
 
-/** Encrypt one account's refresh field (plaintext stays plaintext if no codec change). */
+/** Encrypt one account's refresh/proxy fields (plaintext stays plaintext if no codec change). */
 function encryptAccount(account: ManagedAccount, codec: SecretCodec): ManagedAccount {
-  if (!isEncrypted(account.refresh)) {
-    return { ...account, refresh: codec.encrypt(account.refresh) }
+  let out = account
+  if (!isEncrypted(out.refresh)) {
+    out = { ...out, refresh: codec.encrypt(out.refresh) }
   }
-  return account
+  if (out.proxy && !isEncrypted(out.proxy)) {
+    out = { ...out, proxy: codec.encrypt(out.proxy) }
+  }
+  return out
+}
+
+/** Mask a proxy URL for display/logs: protocol//host:port (no credentials, no query). */
+export function maskProxyUrl(proxyUrl?: string): string | null {
+  if (!proxyUrl) return null
+  try {
+    const u = new URL(proxyUrl)
+    const port = u.port || (u.protocol === 'https:' ? '443' : u.protocol === 'socks5:' || u.protocol === 'socks5h:' ? '1080' : '8080')
+    return `${u.protocol}//${u.hostname}:${port}`
+  } catch {
+    return null
+  }
+}
+
+/** Normalize empty-string proxy to undefined (migration helper). */
+export function normalizeProxyValue(proxy?: string): string | undefined {
+  if (!proxy || !proxy.trim()) return undefined
+  return proxy.trim()
 }
 
 export function ensureAccountIds(storage: AccountStorageV4): { storage: AccountStorageV4; mutated: boolean } {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,8 @@ export interface ManagedAccount {
   fingerprintHistory?: FingerprintVersion[]
   cachedQuota?: Record<string, CachedQuota>
   cachedQuotaUpdatedAt?: number
+  /** Per-account proxy URL (e.g. http://user:pass@host:8080 or socks5://host:1080). Undefined = follow env. */
+  proxy?: string
 }
 
 export interface AccountStorageV1 {
@@ -198,6 +200,7 @@ export type FailureKind =
   | 'project-error'
   | 'request-error'
   | 'transient'
+  | 'proxy-unreachable'
 
 /** Rotation state machine decision for one failed attempt. */
 export type RotationAction =

--- a/src/web/page.ts
+++ b/src/web/page.ts
@@ -771,7 +771,7 @@ export function renderDashboardHtml(): string {
 
         '<div style="margin-top:14px;padding:10px 12px;border:1px solid var(--border-l1);border-radius:8px;background:var(--bg-surface-elevated);display:flex;flex-wrap:wrap;gap:8px;align-items:center;">' +
           '<span style="font-size:13px;font-weight:500;white-space:nowrap;">Proxy:</span>' +
-          '<input id="proxy-input-' + index + '" placeholder="socks5://user:pass@host:1080" style="flex:1;min-width:220px;font-family:var(--ds-font-family-code);font-size:12.5px;padding:6px 10px;background:var(--bg-input);border:1px solid var(--border-l2);border-radius:6px;color:var(--text-primary);outline:none;">' +
+          '<input id="proxy-input-' + selectedIndex + '" placeholder="socks5://user:pass@host:1080" style="flex:1;min-width:220px;font-family:var(--ds-font-family-code);font-size:12.5px;padding:6px 10px;background:var(--bg-input);border:1px solid var(--border-l2);border-radius:6px;color:var(--text-primary);outline:none;">' +
           '<button class="btn btn-primary btn-sm" id="btn-proxy-save">Save</button>' +
           '<button class="btn btn-secondary btn-sm" id="btn-proxy-clear">Clear</button>' +
           '<button class="btn btn-secondary btn-sm" id="btn-proxy-test">Test</button>' +

--- a/src/web/page.ts
+++ b/src/web/page.ts
@@ -767,6 +767,15 @@ export function renderDashboardHtml(): string {
             '<button class="btn btn-secondary btn-sm" id="btn-action-fp">' + esc(t('fingerprint')) + '</button>' +
             '<button class="btn btn-danger btn-sm" id="btn-action-delete">' + esc(t('deleteAccount')) + '</button>' +
           '</div>' +
+          '</div>' +
+
+        '<div style="margin-top:14px;padding:10px 12px;border:1px solid var(--border-l1);border-radius:8px;background:var(--bg-surface-elevated);display:flex;flex-wrap:wrap;gap:8px;align-items:center;">' +
+          '<span style="font-size:13px;font-weight:500;white-space:nowrap;">Proxy:</span>' +
+          '<input id="proxy-input-' + index + '" placeholder="socks5://user:pass@host:1080" style="flex:1;min-width:220px;font-family:var(--ds-font-family-code);font-size:12.5px;padding:6px 10px;background:var(--bg-input);border:1px solid var(--border-l2);border-radius:6px;color:var(--text-primary);outline:none;">' +
+          '<button class="btn btn-primary btn-sm" id="btn-proxy-save">Save</button>' +
+          '<button class="btn btn-secondary btn-sm" id="btn-proxy-clear">Clear</button>' +
+          '<button class="btn btn-secondary btn-sm" id="btn-proxy-test">Test</button>' +
+          '<span id="proxy-status" style="font-size:12px;color:var(--text-secondary);">' + ((a.proxy || a.proxyMasked) ? 'Current: ' + esc(a.proxy || a.proxyMasked) : 'No proxy (using env)') + '</span>' +
         '</div>' +
 
         '<div style="margin-top:16px;">' +
@@ -896,6 +905,58 @@ export function renderDashboardHtml(): string {
         $('diagnostics-output').textContent = lines.join('\\n');
         toast(t('modelsTestedSummary').replace('{total}', String(models.length)).replace('{ok}', String(okCount)).replace('{failed}', String(failCount)), failCount === 0 ? 'success' : 'warn');
         btnTestAll.disabled = false;
+      };
+
+      // Proxy actions
+      const btnProxySave = $('btn-proxy-save');
+      if (btnProxySave) btnProxySave.onclick = async () => {
+        const input = $('proxy-input-' + index);
+        const proxy = input ? input.value.trim() : '';
+        btnProxySave.disabled = true;
+        try {
+          const r = await api('/proxy', { method: 'POST', body: JSON.stringify({ index, proxy }) });
+          const masked = r.proxy || r.proxyMasked || '';
+          const statusEl = $('proxy-status');
+          if (statusEl) statusEl.textContent = masked ? 'Current: ' + masked : 'No proxy (using env)';
+          toast(masked ? 'Proxy saved: ' + masked : 'Proxy cleared (using env)', 'success');
+          render();
+        } catch (e) { toast(String(e), 'error'); }
+        finally { btnProxySave.disabled = false; }
+      };
+      const btnProxyClear = $('btn-proxy-clear');
+      if (btnProxyClear) btnProxyClear.onclick = async () => {
+        btnProxyClear.disabled = true;
+        try {
+          await api('/proxy', { method: 'POST', body: JSON.stringify({ index, proxy: '' }) });
+          const statusEl = $('proxy-status');
+          if (statusEl) statusEl.textContent = 'No proxy (using env)';
+          const input = $('proxy-input-' + index);
+          if (input) input.value = '';
+          toast('Proxy cleared (using env)', 'success');
+          render();
+        } catch (e) { toast(String(e), 'error'); }
+        finally { btnProxyClear.disabled = false; }
+      };
+      const btnProxyTest = $('btn-proxy-test');
+      if (btnProxyTest) btnProxyTest.onclick = async () => {
+        const input = $('proxy-input-' + index);
+        const val = input ? input.value.trim() : '';
+        const body = val ? { index, proxy: val } : { index };
+        btnProxyTest.disabled = true;
+        btnProxyTest.textContent = '...';
+        try {
+          const r = await api('/proxy/test', { method: 'POST', body: JSON.stringify(body) });
+          const masked = r.masked ? esc(r.masked) : '';
+          const statusEl = $('proxy-status');
+          if (r.ok) {
+            toast('Proxy reachable: ' + (r.masked || ''), 'success');
+            if (statusEl) statusEl.textContent = 'Reachable: ' + (r.masked || '');
+          } else {
+            toast('Proxy unreachable: ' + (r.masked || '') + (r.error ? ' - ' + r.error : ''), 'error');
+            if (statusEl) statusEl.textContent = 'Unreachable: ' + (r.masked || '') + (r.error ? ' (' + r.error + ')' : '');
+          }
+        } catch (e) { toast(String(e), 'error'); }
+        finally { btnProxyTest.disabled = false; btnProxyTest.textContent = 'Test'; }
       };
 
       // Single model tests

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -344,7 +344,12 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
   const handleProxy = async (req: IncomingMessage, res: ServerResponse) => {
     try {
       const body = await readJson(req)
-      const index = Number(body.index)
+      const rawIdx = Number(body.index)
+      if (!Number.isInteger(rawIdx) || !Number.isFinite(rawIdx) || rawIdx < 0) {
+        sendJson(res, 400, { error: 'invalid index' })
+        return
+      }
+      const index = rawIdx
       const raw = typeof body.proxy === 'string' ? body.proxy : ''
       if (!raw.trim()) {
         // clear
@@ -377,11 +382,24 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
   const handleProxyTest = async (req: IncomingMessage, res: ServerResponse) => {
     try {
       const body = await readJson(req)
-      const index = Number(body.index)
+      const rawIdx2 = body.index !== undefined ? Number(body.index) : NaN
+      const hasExplicitProxy = typeof body.proxy === 'string' && body.proxy.trim() !== ''
+      if (!hasExplicitProxy) {
+        if (!Number.isInteger(rawIdx2) || !Number.isFinite(rawIdx2) || rawIdx2 < 0) {
+          sendJson(res, 400, { error: 'invalid index' })
+          return
+        }
+      } else if (body.index !== undefined) {
+        if (!Number.isInteger(rawIdx2) || !Number.isFinite(rawIdx2) || rawIdx2 < 0) {
+          sendJson(res, 400, { error: 'invalid index' })
+          return
+        }
+      }
+      const index = hasExplicitProxy && body.index === undefined ? -1 : rawIdx2
       let target: string | undefined
-      if (typeof body.proxy === 'string' && body.proxy.trim() !== '') {
+      if (hasExplicitProxy) {
         try {
-          target = normalizeProxyUrl(body.proxy)
+          target = normalizeProxyUrl(body.proxy as string)
         } catch (e) {
           sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) })
           return
@@ -400,7 +418,7 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
         target = account.proxy
       }
       // mask for response, never raw
-      const masked = maskProxyUrl(target) ?? proxyUrlForLogs(target)
+      const masked = maskProxyUrl(target!) ?? proxyUrlForLogs(target!)
       let ok = false
       let errMsg: string | undefined
       try {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -18,6 +18,8 @@ import { importManySources, upsertImportedAccount } from '../cli/import.ts'
 import { generateFingerprint, recordFingerprintVersion } from '../runtime/fingerprint.ts'
 import { resolveAntigravityVersionBounded } from '../runtime/version.ts'
 import { renderDashboardHtml, renderCallbackHtml } from './page.ts'
+import { maskProxyUrl } from '../store/accounts.ts'
+import { isProxyReachable, normalizeProxyUrl, proxyUrlForLogs } from '../proxy.ts'
 
 export interface WebRoute {
   kind: 'exact' | 'prefix'
@@ -91,6 +93,8 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
           : null,
         fingerprintHistory: (account.fingerprintHistory ?? []).length,
         quota: null as Record<string, unknown> | null,
+        proxy: account.proxy ? maskProxyUrl(account.proxy) : null,
+        proxyMasked: account.proxy ? maskProxyUrl(account.proxy) : null,
       }
       list.push(entry)
     }
@@ -337,6 +341,81 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
     }
   }
 
+  const handleProxy = async (req: IncomingMessage, res: ServerResponse) => {
+    try {
+      const body = await readJson(req)
+      const index = Number(body.index)
+      const raw = typeof body.proxy === 'string' ? body.proxy : ''
+      if (!raw.trim()) {
+        // clear
+        await store.mutate((storage) => {
+          const account = storage.accounts[index]
+          if (!account) throw new Error('account not found')
+          delete account.proxy
+        })
+        sendJson(res, 200, { ok: true, proxy: null, proxyMasked: null, rawLogs: null })
+        return
+      }
+      let normalized: string
+      try {
+        normalized = normalizeProxyUrl(raw)
+      } catch (e) {
+        sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) })
+        return
+      }
+      await store.mutate((storage) => {
+        const account = storage.accounts[index]
+        if (!account) throw new Error('account not found')
+        account.proxy = normalized
+      })
+      sendJson(res, 200, { ok: true, proxy: maskProxyUrl(normalized), proxyMasked: maskProxyUrl(normalized), rawLogs: proxyUrlForLogs(normalized) })
+    } catch (error) {
+      sendJson(res, 400, { error: error instanceof Error ? error.message : String(error) })
+    }
+  }
+
+  const handleProxyTest = async (req: IncomingMessage, res: ServerResponse) => {
+    try {
+      const body = await readJson(req)
+      const index = Number(body.index)
+      let target: string | undefined
+      if (typeof body.proxy === 'string' && body.proxy.trim() !== '') {
+        try {
+          target = normalizeProxyUrl(body.proxy)
+        } catch (e) {
+          sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) })
+          return
+        }
+      } else {
+        const storage = await store.load()
+        const account = storage.accounts[index]
+        if (!account) {
+          sendJson(res, 400, { error: 'account not found' })
+          return
+        }
+        if (!account.proxy) {
+          sendJson(res, 400, { error: 'no proxy configured for this account' })
+          return
+        }
+        target = account.proxy
+      }
+      // mask for response, never raw
+      const masked = maskProxyUrl(target) ?? proxyUrlForLogs(target)
+      let ok = false
+      let errMsg: string | undefined
+      try {
+        ok = await isProxyReachable(target, 2000)
+        if (!ok) errMsg = 'proxy unreachable: ' + masked
+      } catch (e) {
+        ok = false
+        errMsg = e instanceof Error ? e.message : String(e)
+      }
+      sendJson(res, 200, { ok, masked, ...(errMsg ? { error: errMsg } : {}) })
+    } catch (error) {
+      sendJson(res, 400, { error: error instanceof Error ? error.message : String(error) })
+    }
+  }
+
   return [
     { kind: 'exact', path: '/agy', handler: (req, res) => {
       if (req.method === 'GET') {
@@ -362,6 +441,8 @@ export function createAgyWebRoutes(options: AgyWebOptions): WebRoute[] {
     { kind: 'exact', path: '/agy/api/test', handler: handleTest },
     { kind: 'exact', path: '/agy/api/export', handler: handleExport },
     { kind: 'exact', path: '/agy/api/fingerprint', handler: handleFingerprint },
+    { kind: 'exact', path: '/agy/api/proxy', handler: handleProxy },
+    { kind: 'exact', path: '/agy/api/proxy/test', handler: handleProxyTest },
   ]
 }
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -8,4 +8,5 @@ export default defineConfig({
   target: 'es2024',
   dts: true,
   clean: true,
+  external: ['socks-proxy-agent'],
 })


### PR DESCRIPTION
Per-account proxy with fail-closed rotation and docs.

- Adds `socks-proxy-agent` optionalDependency and per-account proxy resolution in `src/proxy.ts`, `src/store/accounts.ts`, `src/session.ts`
- CLI `import` and web dashboard support for per-account proxy config
- Updates `docs/ARCHITECTURE.md` and README

Based on `origin/main` (rebased, dropped local 0.2.3 bump to keep PR clean). 2 commits: `b5b8e5a` + `ea3f4b4`.