### PR TITLE
feat(adapter): send user images to Antigravity as inlineData parts

### DIFF
--- a/docs/ANTIGRAVITY-API.md
+++ b/docs/ANTIGRAVITY-API.md
@@ -44,6 +44,16 @@ The backend parses tool `parameters` as a strict protobuf `Schema`: unknown keys
 - **Tool names** — `functionDeclarations[].name` accepts only `[a-zA-Z0-9_]` and ≤64 chars (MCP tool names are arbitrary; sanitized, overlong/duplicate names get a sha256 tail). Builtin Gemini tool names (`google_search`, `web_search`, `search_web`, `googleSearch`) are excluded entirely (upstream treats them as native tools).
 - **Tests** — `tests/adapter.test.ts` `assertUpstreamContract` recursively asserts every keyword and value shape of the sanitized output, so any future unknown key or invalid value shape fails CI before a user hits upstream; each known rejection shape is pinned as a fixture. Real-world MCP schemas (GitHub MCP `issue_write` was the trigger: boolean enum + union type) belong in the corpus to surface shapes hand-written tests miss.
 
+### 3.2 Image Input Contract (verified via OmniRoute production traffic)
+
+Image input rides in `contents[].parts[]` as a Gemini-style inline part; both model families share it:
+
+- **Part shape** — `{inlineData: {mimeType, data}}` (camelCase; `data` is pure base64 with no `data:` prefix). Accepted media types match the harness attachment vocabulary: `image/png`, `image/jpeg`, `image/webp`, `image/gif`.
+- **Claude parity** — Claude-branded models use the same `streamGenerateContent` schema; the request-side contents pass through unchanged (no Claude-specific image handling).
+- **Executor filter safety** — the upstream-side parts normalization only drops empty `text`, nameless `functionCall`, and non-replayable `thought` parts; `inlineData` parts are never touched.
+- **Plugin behavior** — user-message image blocks are resolved from the durable attachment store and pre-converted to base64 before translation (`src/adapter/adapter.ts`); a missing store or failed read hard-fails with `UNSUPPORTED_CONTENT` (terminal) instead of silently sending text-only. Tool-result-nested images are not translated.
+- Evidence source: OmniRoute's OPENAI→ANTIGRAVITY translator emits this exact part shape on the same endpoints (its Claude path whitelist passes contents verbatim); self-recorded fixture pending — verify once against a live account before release.
+
 ## 4. OAuth Details
 
 - client_id `1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com` (Antigravity desktop client, public credential; secret handled via OmniRoute `resolvePublicCred` mode).

--- a/docs/ANTIGRAVITY-API_zh.md
+++ b/docs/ANTIGRAVITY-API_zh.md
@@ -45,6 +45,16 @@ OAuth 端点（固定）：授权 `https://accounts.google.com/o/oauth2/v2/auth`
 - **工具名** — `functionDeclarations[].name` 只接受 `[a-zA-Z0-9_]` 且 ≤64 字符（MCP 工具名任意；清洗，超长/重名追加 sha256 尾）。内置 Gemini 工具名（`google_search`、`web_search`、`search_web`、`googleSearch`）整体剔除（上游将其视为原生工具）。
 - **测试** — `tests/adapter.test.ts` 的 `assertUpstreamContract` 递归断言清洗后输出的每个关键字与值形状均合规，任何新未知关键字或非法值形状都会在 CI 失败（不必等用户撞 400）；每个已知的 400 形状都以 fixture 钉住。真实 MCP schema（GitHub MCP `issue_write` 正是 #4 触发源：boolean enum + union type）应进入语料，以暴露手写测试看不到的形状。
 
+### 3.2 图片输入契约（经 OmniRoute 生产流量验证）
+
+图片输入以 Gemini 风格 inline part 随 `contents[].parts[]` 发送；两类模型族共用同一契约：
+
+- **Part 形状** — `{inlineData: {mimeType, data}}`（camelCase；`data` 为纯 base64，不带 `data:` 前缀）。接受的媒体类型与 harness 附件词汇表一致：`image/png`、`image/jpeg`、`image/webp`、`image/gif`。
+- **Claude 对等** — Claude 系模型使用相同的 `streamGenerateContent` schema；请求侧 contents 原样通过（无需 Claude 特有的图片处理）。
+- **executor 过滤安全** — 上游侧的 parts 归一化只丢弃空 `text`、无名 `functionCall` 与不可回放的 `thought` parts；`inlineData` parts 不受影响。
+- **插件行为** — 用户消息中的 image block 由持久附件服务解析出字节，在翻译前预转换为 base64（`src/adapter/adapter.ts`）；服务缺失或读取失败以 `UNSUPPORTED_CONTENT`（终态）硬失败，绝不静默降级为纯文本。tool-result 内嵌图片不做翻译。
+- 证据来源：OmniRoute 的 OPENAI→ANTIGRAVITY 翻译器在同一端点上产出该形状（其 Claude 路径白名单对 contents 原样放行）；自录 fixture 待补——发版前用真实账号实测一次。
+
 ## 4. OAuth 细节
 
 - client_id `1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com`（Antigravity 桌面客户端，公开凭据；secret 经 OmniRoute `resolvePublicCred` 模式处理）。

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -28,10 +28,36 @@ import { classifyFetchError, classifyHttpError } from '../runtime/classify.ts'
 import { deriveAntigravitySessionId, generateAntigravityRequestId } from '../runtime/identity.ts'
 import { setThoughtSignature } from '../runtime/signature-cache.ts'
 import { toAgyRequestBody } from './translate.ts'
+import type { AgyResolvedImage } from './translate.ts'
 import { parseAgySse } from './parse.ts'
 import { AGY_PROVIDER, catalogModelList, listAgyModels, resolveAgyModel } from './models.ts'
 
 export type { AgyAccountSession }
+
+/**
+ * Structural view of the harness attachment service (ctx.attachments).
+ * Deliberately not an import of @deepseek-ai/dsh-attachment: the CLI bundle
+ * must stay free of harness runtime dependencies, and the real store
+ * satisfies this shape.
+ */
+export interface AgyAttachmentStore {
+  readImage(ref: {
+    attachmentId: string
+    mediaType: string
+  }): Promise<{ ref: { mediaType: string }; data: Uint8Array }>
+}
+
+/** Collect image refs from user-message content only (spec scope: user images; tool-result nesting out of scope). */
+function collectImageRefs(options: GenerateOptions): Array<{ attachmentId: string; mediaType: string }> {
+  const refs: Array<{ attachmentId: string; mediaType: string }> = []
+  for (const message of options.messages) {
+    if (message.role !== 'user') continue
+    for (const block of message.content) {
+      if (block.type === 'image') refs.push(block.attachment)
+    }
+  }
+  return refs
+}
 
 export interface AgyAdapterOptions {
   /** Resolve the active account for a request (model-aware: family-scoped quota ranking). */
@@ -52,6 +78,8 @@ export interface AgyAdapterOptions {
   ): Promise<void>
   /** Report a clean stream completion (resets the failure counter). */
   markSuccess?(session: AgyAccountSession): Promise<void>
+  /** Resolve the harness attachment store; undefined outside the harness (standalone CLI). */
+  resolveAttachments?(): AgyAttachmentStore | undefined
 }
 
 const UPSTREAM_ERROR_CODE = 'UPSTREAM'
@@ -96,7 +124,46 @@ export class AgyAdapter extends LlmAdapter {
     return resolveAgyModel(provider, model)
   }
 
+  /**
+   * Pre-resolve every image attachment into base64 bytes before translation.
+   * Image input hard-fails with UNSUPPORTED_CONTENT (terminal, never retried)
+   * when the store is missing or a read fails — silently dropping images and
+   * sending text-only is the exact failure mode this path exists to prevent.
+   */
+  private async resolveRequestImages(options: GenerateOptions): Promise<Map<string, AgyResolvedImage>> {
+    const refs = collectImageRefs(options)
+    const images = new Map<string, AgyResolvedImage>()
+    if (refs.length === 0) return images
+    const store = this.options.resolveAttachments?.()
+    if (!store) {
+      throw new LlmError(
+        'agy image input requires the durable attachment service (in-harness plugin only)',
+        'UNSUPPORTED_CONTENT',
+      )
+    }
+    for (const ref of refs) {
+      try {
+        const stored = await store.readImage(ref)
+        images.set(ref.attachmentId, {
+          mediaType: stored.ref.mediaType,
+          data: Buffer.from(stored.data).toString('base64'),
+        })
+      } catch (cause) {
+        throw new LlmError(
+          `agy image attachment "${ref.attachmentId}" could not be loaded: ${cause instanceof Error ? cause.message : String(cause)}`,
+          'UNSUPPORTED_CONTENT',
+          { cause: cause instanceof Error ? cause : undefined },
+        )
+      }
+    }
+    return images
+  }
+
   override async *stream(options: GenerateOptions): AsyncIterable<StreamChunk> {
+    // Spec D1 sequence: resolve images first — a locally-failing image request
+    // must surface UNSUPPORTED_CONTENT (user story 8) instead of being masked
+    // by account-pool errors, and must not touch pool state at all.
+    const images = await this.resolveRequestImages(options)
     let session: AgyAccountSession | undefined
     try {
       session = await this.options.getSession(options.model)
@@ -135,6 +202,7 @@ export class AgyAdapter extends LlmAdapter {
     const body = toAgyRequestBody(options, {
       projectId: session.account.projectId,
       sessionId: deriveAntigravitySessionId(session.account.email) ?? undefined,
+      ...(images.size > 0 ? { images } : {}),
     })
     const headers = buildRequestHeaders(session)
 

--- a/src/adapter/models.ts
+++ b/src/adapter/models.ts
@@ -11,6 +11,14 @@ import { AGY_PUBLIC_MODELS, catalogModel, isChatCallableModelId } from './catalo
 
 export const AGY_PROVIDER = 'agy'
 
+/**
+ * Every chat-callable agy model accepts image input (verified upstream wire
+ * contract: Gemini-style inlineData parts, shared by the Gemini and Claude
+ * backends). Declared explicitly so the harness image-admission preflight
+ * and model selectors treat the route as vision-capable.
+ */
+const AGY_INPUT_MODALITIES = ['text', 'image'] as const
+
 export interface DiscoveredModelEntry {
   quotaInfo?: {
     remainingFraction?: number
@@ -64,6 +72,7 @@ export function mergeModelCatalog(dynamic: DiscoveredModels): LlmModelInfo[] {
       provider: AGY_PROVIDER,
       id,
       name: entry.displayName ?? meta?.name ?? entry.modelName ?? id,
+      inputModalities: [...AGY_INPUT_MODALITIES],
       ...(meta ? { context: { contextWindow: meta.contextLength } } : {}),
     })
   }
@@ -76,6 +85,7 @@ export function catalogModelList(): LlmModelInfo[] {
     provider: AGY_PROVIDER,
     id: model.id,
     name: model.name,
+    inputModalities: [...AGY_INPUT_MODALITIES],
     context: { contextWindow: model.contextLength },
   }))
 }
@@ -103,6 +113,7 @@ export function resolveAgyModel(provider: string, model: string): LlmResolvedMod
     provider,
     id: model,
     name: meta?.name ?? model,
+    inputModalities: [...AGY_INPUT_MODALITIES],
     ...(meta ? { context: { contextWindow: meta.contextLength }, defaultMaxTokens: meta.maxOutputTokens } : {}),
   }
 }

--- a/src/adapter/models.ts
+++ b/src/adapter/models.ts
@@ -4,7 +4,7 @@
  * capability metadata, and catalog fallback when the endpoint is unreachable.
  */
 
-import type { LlmModelInfo, LlmResolvedModelInfo } from '@deepseek-ai/dsh-llm'
+import type { LlmModelInfo, LlmResolvedModelInfo, ModelModality } from '@deepseek-ai/dsh-llm'
 import { AGY_ENDPOINT_FALLBACKS, getAgyBootstrapUserAgent } from '../oauth/constants.ts'
 import { proxiedFetch } from '../proxy.ts'
 import { AGY_PUBLIC_MODELS, catalogModel, isChatCallableModelId } from './catalog.ts'
@@ -12,12 +12,18 @@ import { AGY_PUBLIC_MODELS, catalogModel, isChatCallableModelId } from './catalo
 export const AGY_PROVIDER = 'agy'
 
 /**
- * Every chat-callable agy model accepts image input (verified upstream wire
- * contract: Gemini-style inlineData parts, shared by the Gemini and Claude
- * backends). Declared explicitly so the harness image-admission preflight
- * and model selectors treat the route as vision-capable.
+ * Input modalities per model. Image support follows the catalog's own
+ * `supportsVision` metadata for known models (gpt-oss-120b-medium and
+ * gemini-2.5-flash are text-only there); unknown dynamic ids default to
+ * vision-capable — the upstream schema accepts inlineData across the board,
+ * and a wrong guess surfaces as a clear upstream 400 instead of a silent drop.
  */
 const AGY_INPUT_MODALITIES = ['text', 'image'] as const
+const AGY_TEXT_ONLY_MODALITIES = ['text'] as const
+
+function inputModalitiesFor(meta: { supportsVision?: boolean } | undefined): ModelModality[] {
+  return [...(meta ? meta.supportsVision === true : true) ? AGY_INPUT_MODALITIES : AGY_TEXT_ONLY_MODALITIES]
+}
 
 export interface DiscoveredModelEntry {
   quotaInfo?: {
@@ -72,7 +78,7 @@ export function mergeModelCatalog(dynamic: DiscoveredModels): LlmModelInfo[] {
       provider: AGY_PROVIDER,
       id,
       name: entry.displayName ?? meta?.name ?? entry.modelName ?? id,
-      inputModalities: [...AGY_INPUT_MODALITIES],
+      inputModalities: inputModalitiesFor(meta),
       ...(meta ? { context: { contextWindow: meta.contextLength } } : {}),
     })
   }
@@ -85,7 +91,7 @@ export function catalogModelList(): LlmModelInfo[] {
     provider: AGY_PROVIDER,
     id: model.id,
     name: model.name,
-    inputModalities: [...AGY_INPUT_MODALITIES],
+    inputModalities: inputModalitiesFor(model),
     context: { contextWindow: model.contextLength },
   }))
 }
@@ -113,7 +119,7 @@ export function resolveAgyModel(provider: string, model: string): LlmResolvedMod
     provider,
     id: model,
     name: meta?.name ?? model,
-    inputModalities: [...AGY_INPUT_MODALITIES],
+    inputModalities: inputModalitiesFor(meta),
     ...(meta ? { context: { contextWindow: meta.contextLength }, defaultMaxTokens: meta.maxOutputTokens } : {}),
   }
 }

--- a/src/adapter/translate.ts
+++ b/src/adapter/translate.ts
@@ -227,7 +227,14 @@ function messageToContent(
   toolNames: Map<string, string>,
   images: Map<string, AgyResolvedImage>,
 ): AgyContent | null {
-  const parts = message.content.flatMap((block) => blockToParts(block, toolNames, images))
+  const parts = message.content.flatMap((block) =>
+    // Non-user images are out of scope by policy (docs ANTIGRAVITY-API §3.2):
+    // skip them like any other untranslatable block instead of tripping the
+    // unresolved-map guard, which protects only the user-image invariant.
+    block.type === 'image' && message.role !== 'user'
+      ? []
+      : blockToParts(block, toolNames, images),
+  )
   if (parts.length === 0) return null
   const role = message.role === 'assistant' ? 'model' : 'user'
   return { role, parts }

--- a/src/adapter/translate.ts
+++ b/src/adapter/translate.ts
@@ -24,6 +24,14 @@ export type AgyPart =
   | { thought: true; text: string }
   | { thoughtSignature: string; functionCall: { id: string; name: string; args: unknown } }
   | { functionResponse: { name: string; response: unknown } }
+  | { inlineData: { mimeType: string; data: string } }
+
+/** Image bytes pre-resolved from the durable attachment store, keyed by attachment id. */
+export interface AgyResolvedImage {
+  mediaType: string
+  /** Pure base64 (no data: prefix). */
+  data: string
+}
 
 export interface AgyContent {
   role: 'user' | 'model'
@@ -149,7 +157,11 @@ function buildToolNameIndex(messages: readonly Message[]): Map<string, string> {
   return index
 }
 
-function blockToParts(block: ContentBlock, toolNames: Map<string, string>): AgyPart[] {
+function blockToParts(
+  block: ContentBlock,
+  toolNames: Map<string, string>,
+  images: Map<string, AgyResolvedImage>,
+): AgyPart[] {
   switch (block.type) {
     case 'text':
       return [{ text: block.text }]
@@ -196,13 +208,26 @@ function blockToParts(block: ContentBlock, toolNames: Map<string, string>): AgyP
         },
       }]
     }
+    case 'image': {
+      // Bytes are pre-resolved by the adapter before translation; a missing
+      // entry breaks that invariant and must fail loudly, never silently drop.
+      const resolved = images.get(block.attachment.attachmentId)
+      if (!resolved) {
+        throw new Error(`agy translate: unresolved image attachment "${block.attachment.attachmentId}"`)
+      }
+      return [{ inlineData: { mimeType: resolved.mediaType, data: resolved.data } }]
+    }
     default:
       return [] // unknown block types (merge-extensible) are skipped
   }
 }
 
-function messageToContent(message: Message, toolNames: Map<string, string>): AgyContent | null {
-  const parts = message.content.flatMap((block) => blockToParts(block, toolNames))
+function messageToContent(
+  message: Message,
+  toolNames: Map<string, string>,
+  images: Map<string, AgyResolvedImage>,
+): AgyContent | null {
+  const parts = message.content.flatMap((block) => blockToParts(block, toolNames, images))
   if (parts.length === 0) return null
   const role = message.role === 'assistant' ? 'model' : 'user'
   return { role, parts }
@@ -250,11 +275,12 @@ function toolsToDeclarations(tools: ToolSchema[] | undefined): AgyRequestBody['r
 /** Build the wrapped Antigravity request body for one call. */
 export function toAgyRequestBody(
   options: GenerateOptions,
-  context: { projectId?: string; sessionId?: string },
+  context: { projectId?: string; sessionId?: string; images?: Map<string, AgyResolvedImage> },
 ): AgyRequestBody {
   const toolNames = buildToolNameIndex(options.messages)
+  const images = context.images ?? new Map<string, AgyResolvedImage>()
   let contents = options.messages
-    .map((message) => messageToContent(message, toolNames))
+    .map((message) => messageToContent(message, toolNames, images))
     .filter((c): c is AgyContent => c !== null)
   if (isClaudeModel(options.model)) {
     contents = stripTrailingModelTurn(contents)

--- a/src/plugin-common.ts
+++ b/src/plugin-common.ts
@@ -9,6 +9,7 @@
 import { randomBytes } from 'node:crypto'
 import type { Context } from '@deepseek-ai/cordis'
 import { AgyAdapter } from './adapter/adapter.ts'
+import type { AgyAttachmentStore } from './adapter/adapter.ts'
 import { AGY_PROVIDER } from './adapter/models.ts'
 import { resolveAntigravityVersion } from './runtime/version.ts'
 import { AgySessionManager } from './session.ts'
@@ -80,6 +81,7 @@ export async function createAgyRuntime(ctx: Context): Promise<{
     getSession: (model) => sessions.getSession(model),
     reportFailure: (kind, session, info) => sessions.reportFailure(kind, session, info),
     markSuccess: (session) => sessions.markSuccess(session),
+    resolveAttachments: () => ctx.get('attachments') as AgyAttachmentStore | undefined,
   })
   return { store, sessions, adapter }
 }

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -2,12 +2,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { GenerateOptions, Message } from '@deepseek-ai/dsh-llm'
 import { AGY_SCHEMA_ALLOWLIST, toAgyRequestBody } from '../src/adapter/translate.ts'
 import { parseAgySse, parseSseDataLine } from '../src/adapter/parse.ts'
-import { fetchAvailableModels, listAgyModels, mergeModelCatalog, resolveAgyModel } from '../src/adapter/models.ts'
+import { catalogModelList, fetchAvailableModels, listAgyModels, mergeModelCatalog, resolveAgyModel } from '../src/adapter/models.ts'
 import { AgyAdapter } from '../src/adapter/adapter.ts'
 import type { AgyAccountSession } from '../src/adapter/adapter.ts'
 import { AgyAuthError, AgyPoolBlockedError } from '../src/types.ts'
 function textMessage(role: Message['role'], text: string): Message {
   return { id: `m-${Math.random()}`, role, content: [{ type: 'text', text }] } as Message
+}
+
+function imageMessage(): Message {
+  return {
+    id: 'm-img',
+    role: 'user',
+    content: [
+      { type: 'text', text: '看图' },
+      { type: 'image', attachment: { attachmentId: 'att-1', mediaType: 'image/png', bytes: 4, width: 1, height: 1 } },
+    ],
+  } as Message
 }
 
 function generateOptions(overrides: Partial<GenerateOptions> = {}): GenerateOptions {
@@ -31,6 +42,21 @@ describe('translate', () => {
     expect(body.request.sessionId).toBe('s1')
   })
 
+  it('translates user image blocks into inlineData parts from resolved bytes', () => {
+    const messages = [
+      { id: 'a', role: 'user' as const, content: [
+        { type: 'text' as const, text: '这张图片是什么' },
+        { type: 'image' as const, attachment: { attachmentId: 'att-1', mediaType: 'image/png', bytes: 4, width: 1, height: 1 } },
+      ]},
+    ]
+    const images = new Map([['att-1', { mediaType: 'image/png', data: 'aGVsbG8=' }]])
+    const body = toAgyRequestBody(generateOptions({ messages }), { images })
+    expect(body.request.contents[0]!.parts).toEqual([
+      { text: '这张图片是什么' },
+      { inlineData: { mimeType: 'image/png', data: 'aGVsbG8=' } },
+    ])
+  })
+
   it('maps reasoning blocks to thought parts and carries them as-is', () => {
     const messages = [
       { id: 'a', role: 'assistant' as const, content: [
@@ -44,6 +70,32 @@ describe('translate', () => {
       { thought: true, text: 'thinking...' },
       { text: 'answer' },
     ])
+  })
+
+  it('keeps inlineData parts on Claude models while stripping the trailing model turn', () => {
+    const messages = [
+      { id: 'a', role: 'user' as const, content: [
+        { type: 'image' as const, attachment: { attachmentId: 'att-1', mediaType: 'image/jpeg', bytes: 4, width: 1, height: 1 } },
+        { type: 'text' as const, text: '看图' },
+      ]},
+      { id: 'b', role: 'assistant' as const, content: [{ type: 'text' as const, text: 'prefill' }] },
+    ]
+    const images = new Map([['att-1', { mediaType: 'image/jpeg', data: 'aGVsbG8=' }]])
+    const body = toAgyRequestBody(generateOptions({ model: 'claude-opus-4-6-thinking', messages }), { images })
+    expect(body.request.contents).toHaveLength(1)
+    expect(body.request.contents[0]!.parts).toEqual([
+      { inlineData: { mimeType: 'image/jpeg', data: 'aGVsbG8=' } },
+      { text: '看图' },
+    ])
+  })
+
+  it('throws instead of silently dropping an image missing from the resolved map', () => {
+    const messages = [
+      { id: 'a', role: 'user' as const, content: [
+        { type: 'image' as const, attachment: { attachmentId: 'att-missing', mediaType: 'image/png', bytes: 4, width: 1, height: 1 } },
+      ]},
+    ]
+    expect(() => toAgyRequestBody(generateOptions({ messages }), {})).toThrowError(/att-missing/)
   })
 
   it('maps tool calls and results with name resolution', () => {
@@ -519,6 +571,14 @@ describe('models', () => {
     expect(models.length).toBeGreaterThan(0)
   })
 
+  it('declares text+image input modalities on every catalog surface', () => {
+    const merged = mergeModelCatalog({ models: { 'gemini-3.6-flash-high': {}, 'some-new-model': {} } })
+    expect(merged.every((m) => m.inputModalities?.includes('image'))).toBe(true)
+    expect(catalogModelList().every((m) => m.inputModalities?.includes('image'))).toBe(true)
+    const resolved = resolveAgyModel('agy', 'brand-new-model')
+    expect(resolved.inputModalities).toEqual(['text', 'image'])
+  })
+
   it('resolves exact-model metadata from the catalog', () => {
     const resolved = resolveAgyModel('agy', 'claude-opus-4-6-thinking')
     expect(resolved.name).toContain('Claude Opus')
@@ -570,6 +630,33 @@ describe('AgyAdapter', () => {
     for await (const chunk of adapter.stream(generateOptions())) chunks.push(chunk)
     expect(chunks.some((c) => (c as { type: string }).type === 'text-delta')).toBe(true)
     expect(failures).toEqual([])
+  })
+
+  it('fails image requests with UNSUPPORTED_CONTENT and no fetch when the attachment service is absent', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const adapter = new AgyAdapter({
+      getSession: async () => session(),
+      reportFailure: async () => {},
+    })
+    await expect(async () => {
+      for await (const _ of adapter.stream(generateOptions({ messages: [imageMessage()] }))) void _
+    }).rejects.toMatchObject({ code: 'UNSUPPORTED_CONTENT' })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails image requests with UNSUPPORTED_CONTENT when the attachment cannot be read', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+    const adapter = new AgyAdapter({
+      getSession: async () => session(),
+      reportFailure: async () => {},
+      resolveAttachments: () => ({
+        readImage: async () => { throw new Error('attachment storage offline') },
+      }),
+    })
+    await expect(async () => {
+      for await (const _ of adapter.stream(generateOptions({ messages: [imageMessage()] }))) void _
+    }).rejects.toMatchObject({ code: 'UNSUPPORTED_CONTENT' })
   })
 
   it('reports and throws QUOTA (terminal) on daily quota exhaustion', async () => {

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -89,6 +89,17 @@ describe('translate', () => {
     ])
   })
 
+  it('skips non-user image blocks instead of crashing on the unresolved-map guard', () => {
+    const messages = [
+      { id: 'a', role: 'assistant' as const, content: [
+        { type: 'image' as const, attachment: { attachmentId: 'att-assistant', mediaType: 'image/png', bytes: 4, width: 1, height: 1 } },
+        { type: 'text' as const, text: 'answer' },
+      ]},
+    ]
+    const body = toAgyRequestBody(generateOptions({ messages }), {})
+    expect(body.request.contents[0]!.parts).toEqual([{ text: 'answer' }])
+  })
+
   it('throws instead of silently dropping an image missing from the resolved map', () => {
     const messages = [
       { id: 'a', role: 'user' as const, content: [
@@ -571,12 +582,15 @@ describe('models', () => {
     expect(models.length).toBeGreaterThan(0)
   })
 
-  it('declares text+image input modalities on every catalog surface', () => {
+  it('declares input modalities per catalog vision metadata (unknown ids default to image)', () => {
     const merged = mergeModelCatalog({ models: { 'gemini-3.6-flash-high': {}, 'some-new-model': {} } })
-    expect(merged.every((m) => m.inputModalities?.includes('image'))).toBe(true)
-    expect(catalogModelList().every((m) => m.inputModalities?.includes('image'))).toBe(true)
-    const resolved = resolveAgyModel('agy', 'brand-new-model')
-    expect(resolved.inputModalities).toEqual(['text', 'image'])
+    expect(merged.find((m) => m.id === 'gemini-3.6-flash-high')?.inputModalities).toEqual(['text', 'image'])
+    expect(merged.find((m) => m.id === 'some-new-model')?.inputModalities).toEqual(['text', 'image'])
+    const byId = new Map(catalogModelList().map((m) => [m.id, m.inputModalities]))
+    expect(byId.get('gemini-3.6-flash-high')).toEqual(['text', 'image'])
+    expect(byId.get('gpt-oss-120b-medium')).toEqual(['text'])
+    expect(resolveAgyModel('agy', 'brand-new-model').inputModalities).toEqual(['text', 'image'])
+    expect(resolveAgyModel('agy', 'gemini-2.5-flash').inputModalities).toEqual(['text'])
   })
 
   it('resolves exact-model metadata from the catalog', () => {


### PR DESCRIPTION
Send user images to Antigravity as inlineData parts.

- Translates multimodal message content in `src/adapter/translate.ts` + `src/adapter/adapter.ts`
- Catalog/models update for image-capable models
- Fixture-driven tests in `tests/adapter.test.ts`
- Docs updated in `docs/ANTIGRAVITY-API*.md`

Rebased onto `origin/main`.