### PR TITLE
feat(adapter): add thinkingLevel for tiered Gemini models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ npm pack --dry-run           # Verify packaged files before release (npm ships w
 - `AGY_CLIENT_ID` and `AGY_CLIENT_SECRET` are **public client credentials** embedded in the Antigravity desktop application; they are not project secrets — do not "fix" them by deletion or obfuscation.
 - Upstream tool-schema 400s are fixed by extending the contract (`sanitizeToolSchema` + a fixture test), never by one-off keyword patches — contract, values, and corpus are pinned in `docs/ANTIGRAVITY-API.md` §3.1.
 - **Session affinity**: `AgySessionManager` pins requests to the last-used account for `SESSION_AFFINITY_WINDOW_MS` (upstream prefix-cache + sessionId continuity; DSH exposes no conversation id, so the window is the proxy). Rotation clears the pin.
+- **Model catalog (AGY)**: `src/adapter/catalog.ts` is the capability source; `v1internal:fetchAvailableModels` is the liveness source. For a new model with selectable thinking (single id + `low/medium/high`), add one `AGY_PUBLIC_MODELS` entry with `thinking:'level'` (omit = id-bound). `src/adapter/models.ts` (`isLevelThinkingModel`) and `src/adapter/translate.ts` then auto-expose `reasoning` and `generationConfig.thinkingConfig.thinkingLevel` — no logic change. Legacy id-bound ids stay without `thinking`.
 - Commit messages follow Conventional Commits (`fix(scope): ...`, `feat(scope): ...`).
 - `docs/` is not bundled with npm: links from `README.md` to `docs/` must resolve properly on GitHub.
 - Docs are maintained as EN + zh mirrors (`docs/*_zh.md`); any update to one must update the other in the same commit.

--- a/docs/ANTIGRAVITY-API.md
+++ b/docs/ANTIGRAVITY-API.md
@@ -34,6 +34,7 @@ OAuth endpoints (fixed): authorize `https://accounts.google.com/o/oauth2/v2/auth
 - `Client-Metadata` actually only sends `{ideType:"ANTIGRAVITY"}` in code (freely-added `platform`/`pluginType` get rejected by backend enum validation).
 - Dual style (antigravity vs gemini-cli) **not done**.
 - **Request envelope (OmniRoute active format)**: top level `{project, requestId, model, userAgent:"antigravity", requestType:"agent", request:{contents, tools?, toolConfig:{functionCallingConfig:{mode:"VALIDATED"}}, generationConfig?, sessionId}}`. Claude models strip the trailing model turn; tool schemas are reduced to an upstream allowlist with normalized keyword values (backend rejects ANY unknown keyword AND any non-protobuf value shape; see §3.1).
+- **generationConfig.thinkingConfig** (level-thinking models only): `{thinkingLevel:"low"|"medium"|"high", includeThoughts:true}`. Only emitted when `catalog thinking==='level'` and `GenerateOptions.reasoningEffort` is one of the three; otherwise absent. Id-bound models (e.g. `gemini-3.6-flash-high`, `claude-*`) never carry it; upstream rejects a level on an id-bound model with 400. Example (current `gemini-3.7-flash-tiered`; future `gemini-4-flash` without `-tiered` suffix behaves identically when marked `thinking:'level'`): `{"model":"gemini-3.7-flash-tiered","request":{"generationConfig":{"thinkingConfig":{"thinkingLevel":"medium","includeThoughts":true}}}}`.
 
 ### 3.1 Tool Schema Contract (verified; whack-a-mole defense)
 

--- a/docs/ANTIGRAVITY-API_zh.md
+++ b/docs/ANTIGRAVITY-API_zh.md
@@ -35,6 +35,7 @@ OAuth 端点（固定）：授权 `https://accounts.google.com/o/oauth2/v2/auth`
 - `Client-Metadata` 代码实际只发 `{ideType:"ANTIGRAVITY"}`（凭空多发的 `platform`/`pluginType` 会被后端枚举校验拒绝）。
 - 双风格（antigravity vs gemini-cli）**不做**。
 - **请求 envelope（OmniRoute 活跃格式）**：顶层 `{project, requestId, model, userAgent:"antigravity", requestType:"agent", request:{contents, tools?, toolConfig:{functionCallingConfig:{mode:"VALIDATED"}}, generationConfig?, sessionId}}`。Claude 模型剥离尾部 model 轮；工具 schema 被裁剪到上游 allowlist 并归一化关键字值（后端拒绝任何未知关键字**以及**任何不符合 protobuf 形状的值；见 §3.1）。
+- **generationConfig.thinkingConfig**（仅 level-thinking 模型，单 id + 可选档）：`{thinkingLevel:"low"|"medium"|"high", includeThoughts:true}`。仅当 `catalog thinking==='level'` 且 `GenerateOptions.reasoningEffort` 为三档之一时发送；其余不带。Id 绑定模型（如 `gemini-3.6-flash-high`、`claude-*`）永不携带，误带上游 400。示例（当前 `gemini-3.7-flash-tiered`；未来 `gemini-4-flash` 无 `-tiered` 后缀但标 `thinking:'level'` 时行为一致）：`{"model":"gemini-3.7-flash-tiered","request":{"generationConfig":{"thinkingConfig":{"thinkingLevel":"medium","includeThoughts":true}}}}`。
 
 ### 3.1 工具 Schema 契约（实测确认；防打地鼠防线）
 

--- a/src/adapter/catalog.ts
+++ b/src/adapter/catalog.ts
@@ -16,12 +16,15 @@ export interface CatalogModel {
   supportsReasoning?: boolean
   supportsVision?: boolean
   toolCalling?: boolean
+  /** Level-thinking: 'level' means single id + selectable low/medium/high via thinkingLevel. Omit = level bound to id. */
+  thinking?: 'level'
 }
 
 export const AGY_PUBLIC_MODELS: readonly CatalogModel[] = [
   { id: 'gemini-3.6-flash-high', name: 'Gemini 3.6 Flash (High)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'gemini-3.6-flash-medium', name: 'Gemini 3.6 Flash (Medium)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'gemini-3.6-flash-low', name: 'Gemini 3.6 Flash (Low)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
+  { id: 'gemini-3.7-flash-tiered', name: 'Gemini 3.7 Flash', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true, thinking: 'level' },
   { id: 'claude-opus-4-6-thinking', name: 'Claude Opus 4.6 (Thinking)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6 (Thinking)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'gemini-pro-agent', name: 'Gemini 3.1 Pro (High)', contextLength: 1048576, maxOutputTokens: 65535, supportsReasoning: true, supportsVision: true, toolCalling: true },
@@ -45,4 +48,9 @@ export function isChatCallableModelId(modelId: string): boolean {
 
 export function catalogModel(modelId: string): CatalogModel | undefined {
   return CATALOG_BY_ID.get(modelId)
+}
+
+/** Level-thinking models: single id + selectable low/medium/high via thinkingLevel. */
+export function isLevelThinkingModel(modelId: string): boolean {
+  return catalogModel(modelId)?.thinking === 'level'
 }

--- a/src/adapter/models.ts
+++ b/src/adapter/models.ts
@@ -4,12 +4,22 @@
  * capability metadata, and catalog fallback when the endpoint is unreachable.
  */
 
-import type { LlmModelInfo, LlmResolvedModelInfo, ModelModality } from '@deepseek-ai/dsh-llm'
+import { ReasoningEffortId, type LlmModelInfo, type LlmModelReasoningInfo, type LlmResolvedModelInfo, type ModelModality } from '@deepseek-ai/dsh-llm'
 import { AGY_ENDPOINT_FALLBACKS, getAgyBootstrapUserAgent } from '../oauth/constants.ts'
 import { proxiedFetch } from '../proxy.ts'
-import { AGY_PUBLIC_MODELS, catalogModel, isChatCallableModelId } from './catalog.ts'
+import { AGY_PUBLIC_MODELS, catalogModel, isChatCallableModelId, isLevelThinkingModel } from './catalog.ts'
 
 export const AGY_PROVIDER = 'agy'
+
+/** Level-thinking: single id + selectable low/medium/high via thinkingLevel. Default is UI hint, not wire default. */
+const LEVEL_REASONING: LlmModelReasoningInfo = Object.freeze({
+  efforts: Object.freeze([
+    { id: ReasoningEffortId('low'), name: 'Low' },
+    { id: ReasoningEffortId('medium'), name: 'Medium' },
+    { id: ReasoningEffortId('high'), name: 'High' },
+  ] as const),
+  defaultEffort: ReasoningEffortId('medium'),
+} as const)
 
 /**
  * Input modalities per model. Image support follows the catalog's own
@@ -115,6 +125,17 @@ export async function listAgyModels(
 /** Resolve one exact model's metadata (catalog-backed; dynamic ids pass through). */
 export function resolveAgyModel(provider: string, model: string): LlmResolvedModelInfo {
   const meta = catalogModel(model)
+  if (isLevelThinkingModel(model)) {
+    return {
+      provider,
+      id: model,
+      name: meta?.name ?? model,
+      context: { contextWindow: meta?.contextLength ?? 1048576 },
+      defaultMaxTokens: meta?.maxOutputTokens ?? 65536,
+      // Return a shallow copy so callers cannot mutate the frozen singleton.
+      reasoning: { ...LEVEL_REASONING, efforts: [...LEVEL_REASONING.efforts] },
+    }
+  }
   return {
     provider,
     id: model,

--- a/src/adapter/translate.ts
+++ b/src/adapter/translate.ts
@@ -18,6 +18,7 @@ import { createHash } from 'node:crypto'
 import type { ContentBlock, GenerateOptions, Message, ToolSchema } from '@deepseek-ai/dsh-llm'
 import { generateAntigravityRequestId } from '../runtime/identity.ts'
 import { getThoughtSignature, THOUGHT_SIGNATURE_SENTINEL } from '../runtime/signature-cache.ts'
+import { catalogModel, isLevelThinkingModel } from './catalog.ts'
 
 export type AgyPart =
   | { text: string }
@@ -53,6 +54,7 @@ export interface AgyRequestBody {
       temperature?: number
       maxOutputTokens?: number
       stopSequences?: string[]
+      thinkingConfig?: { thinkingLevel: string; includeThoughts: boolean }
     }
     sessionId?: string
   }
@@ -246,6 +248,9 @@ function messageToContent(
  */
 const AGY_BUILTIN_TOOL_NAMES = new Set(['google_search', 'web_search', 'search_web', 'googleSearch'])
 
+/** Level-thinking: single id + selectable low/medium/high via thinkingLevel (catalog thinking:'level'). */
+const LEVEL_THINKING_LEVELS = new Set(['low', 'medium', 'high'])
+
 /** Upstream functionDeclarations names are `[a-zA-Z0-9_]` and ≤64 chars (OmniRoute-verified). */
 const AGY_TOOL_NAME_MAX_LENGTH = 64
 
@@ -298,6 +303,12 @@ export function toAgyRequestBody(
   if (options.temperature !== undefined) generationConfig.temperature = options.temperature
   if (options.maxTokens !== undefined) generationConfig.maxOutputTokens = options.maxTokens
   if (options.stop !== undefined && options.stop.length > 0) generationConfig.stopSequences = options.stop
+  // Level-thinking: map the DSH reasoning effort to thinkingConfig.
+  // Id-bound models (thinking !== 'level') never emit it — default is UI hint, not wire default.
+  const effort = options.reasoningEffort?.toLowerCase()
+  if (effort && isLevelThinkingModel(options.model) && LEVEL_THINKING_LEVELS.has(effort)) {
+    generationConfig.thinkingConfig = { thinkingLevel: effort, includeThoughts: true }
+  }
 
   return {
     project: context.projectId || undefined,

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -601,6 +601,35 @@ describe('models', () => {
     expect(unknown.name).toBe('brand-new-model')
     expect(unknown.defaultMaxTokens).toBeUndefined()
   })
+
+  it('exposes reasoning efforts for tiered models', () => {
+    const resolved = resolveAgyModel('agy', 'gemini-3.7-flash-tiered')
+    expect(resolved.reasoning).toBeDefined()
+    expect(resolved.reasoning!.efforts.map((e) => String(e.id))).toEqual(['low', 'medium', 'high'])
+    expect(String(resolved.reasoning!.defaultEffort)).toBe('medium')
+    // legacy id-bound models and non-tiered discovered ids must not expose reasoning
+    for (const id of ['gemini-3.6-flash-high', 'gemini-3.6-flash-tiered', 'gemini-2.5-flash']) {
+      expect(resolveAgyModel('agy', id).reasoning).toBeUndefined()
+    }
+  })
+
+  it('maps reasoningEffort to thinkingConfig for tiered models only', () => {
+    const low = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered', reasoningEffort: 'low' as any }), {})
+    expect(low.request.generationConfig).toMatchObject({ thinkingConfig: { thinkingLevel: 'low', includeThoughts: true } })
+    const medium = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered', reasoningEffort: 'medium' as any }), {})
+    expect(medium.request.generationConfig).toMatchObject({ thinkingConfig: { thinkingLevel: 'medium', includeThoughts: true } })
+    const high = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered', reasoningEffort: 'high' as any }), {})
+    expect(high.request.generationConfig).toMatchObject({ thinkingConfig: { thinkingLevel: 'high', includeThoughts: true } })
+
+    const noEffort = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered' }), {})
+    expect(noEffort.request.generationConfig?.thinkingConfig).toBeUndefined()
+
+    const fixedModel = toAgyRequestBody(generateOptions({ model: 'gemini-3.6-flash-high', reasoningEffort: 'high' as any }), {})
+    expect(fixedModel.request.generationConfig?.thinkingConfig).toBeUndefined()
+
+    const invalid = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered', reasoningEffort: 'ultra' as any }), {})
+    expect(invalid.request.generationConfig?.thinkingConfig).toBeUndefined()
+  })
 })
 
 describe('AgyAdapter', () => {


### PR DESCRIPTION
Add thinkingLevel for tiered Gemini models (gemini-3.7/3.6-flash-tiered).

- Model catalog entries in `src/adapter/catalog.ts` / `models.ts`
- Translate `thinkingLevel` in `src/adapter/translate.ts`
- Tests in `tests/adapter.test.ts`

Rebased onto `origin/main`.