### PR TITLE
feat(catalog): add supportsVision for Gemini 2.5/3.1 series and preserve inputModalities on level-thinking models

### DIFF
--- a/src/adapter/catalog.ts
+++ b/src/adapter/catalog.ts
@@ -21,10 +21,11 @@ export interface CatalogModel {
 }
 
 export const AGY_PUBLIC_MODELS: readonly CatalogModel[] = [
+  { id: 'gemini-3.7-flash-tiered', name: 'Gemini 3.7 Flash', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true, thinking: 'level' },
+  { id: 'gemini-3.6-flash-tiered', name: 'Gemini 3.6 Flash (Tiered)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true, thinking: 'level' },
   { id: 'gemini-3.6-flash-high', name: 'Gemini 3.6 Flash (High)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'gemini-3.6-flash-medium', name: 'Gemini 3.6 Flash (Medium)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'gemini-3.6-flash-low', name: 'Gemini 3.6 Flash (Low)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
-  { id: 'gemini-3.7-flash-tiered', name: 'Gemini 3.7 Flash', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true, thinking: 'level' },
   { id: 'claude-opus-4-6-thinking', name: 'Claude Opus 4.6 (Thinking)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6 (Thinking)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'gemini-pro-agent', name: 'Gemini 3.1 Pro (High)', contextLength: 1048576, maxOutputTokens: 65535, supportsReasoning: true, supportsVision: true, toolCalling: true },
@@ -32,10 +33,10 @@ export const AGY_PUBLIC_MODELS: readonly CatalogModel[] = [
   { id: 'gemini-3-flash-agent', name: 'Gemini 3.5 Flash (High)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'gemini-3.5-flash-low', name: 'Gemini 3.5 Flash (Medium)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
   { id: 'gemini-3.5-flash-extra-low', name: 'Gemini 3.5 Flash (Low)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
-  { id: 'gemini-3.1-flash-lite', name: 'Gemini 3.1 Flash Lite', contextLength: 1048576, maxOutputTokens: 65535, toolCalling: true },
-  { id: 'gemini-2.5-flash-thinking', name: 'Gemini 2.5 Flash Thinking', contextLength: 1048576, maxOutputTokens: 65535, supportsReasoning: true, toolCalling: true },
-  { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', contextLength: 1048576, maxOutputTokens: 65535, toolCalling: true },
-  { id: 'gemini-2.5-flash-lite', name: 'Gemini 2.5 Flash Lite', contextLength: 1048576, maxOutputTokens: 65535, toolCalling: true },
+  { id: 'gemini-3.1-flash-lite', name: 'Gemini 3.1 Flash Lite', contextLength: 1048576, maxOutputTokens: 65535, supportsVision: true, toolCalling: true },
+  { id: 'gemini-2.5-flash-thinking', name: 'Gemini 2.5 Flash Thinking', contextLength: 1048576, maxOutputTokens: 65535, supportsReasoning: true, supportsVision: true, toolCalling: true },
+  { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', contextLength: 1048576, maxOutputTokens: 65535, supportsVision: true, toolCalling: true },
+  { id: 'gemini-2.5-flash-lite', name: 'Gemini 2.5 Flash Lite', contextLength: 1048576, maxOutputTokens: 65535, supportsVision: true, toolCalling: true },
   { id: 'gpt-oss-120b-medium', name: 'GPT-OSS 120B (Medium)', contextLength: 131072, maxOutputTokens: 32768, supportsReasoning: true, toolCalling: true },
 ]
 

--- a/src/adapter/models.ts
+++ b/src/adapter/models.ts
@@ -23,10 +23,10 @@ const LEVEL_REASONING: LlmModelReasoningInfo = Object.freeze({
 
 /**
  * Input modalities per model. Image support follows the catalog's own
- * `supportsVision` metadata for known models (gpt-oss-120b-medium and
- * gemini-2.5-flash are text-only there); unknown dynamic ids default to
- * vision-capable — the upstream schema accepts inlineData across the board,
- * and a wrong guess surfaces as a clear upstream 400 instead of a silent drop.
+ * `supportsVision` metadata for known models (gpt-oss-120b-medium is text-only
+ * there); unknown dynamic ids default to vision-capable — the upstream schema
+ * accepts inlineData across the board, and a wrong guess surfaces as a clear
+ * upstream 400 instead of a silent drop.
  */
 const AGY_INPUT_MODALITIES = ['text', 'image'] as const
 const AGY_TEXT_ONLY_MODALITIES = ['text'] as const
@@ -130,6 +130,7 @@ export function resolveAgyModel(provider: string, model: string): LlmResolvedMod
       provider,
       id: model,
       name: meta?.name ?? model,
+      inputModalities: inputModalitiesFor(meta),
       context: { contextWindow: meta?.contextLength ?? 1048576 },
       defaultMaxTokens: meta?.maxOutputTokens ?? 65536,
       // Return a shallow copy so callers cannot mutate the frozen singleton.

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -588,9 +588,11 @@ describe('models', () => {
     expect(merged.find((m) => m.id === 'some-new-model')?.inputModalities).toEqual(['text', 'image'])
     const byId = new Map(catalogModelList().map((m) => [m.id, m.inputModalities]))
     expect(byId.get('gemini-3.6-flash-high')).toEqual(['text', 'image'])
+    expect(byId.get('gemini-2.5-flash')).toEqual(['text', 'image'])
     expect(byId.get('gpt-oss-120b-medium')).toEqual(['text'])
     expect(resolveAgyModel('agy', 'brand-new-model').inputModalities).toEqual(['text', 'image'])
-    expect(resolveAgyModel('agy', 'gemini-2.5-flash').inputModalities).toEqual(['text'])
+    expect(resolveAgyModel('agy', 'gemini-2.5-flash').inputModalities).toEqual(['text', 'image'])
+    expect(resolveAgyModel('agy', 'gemini-3.7-flash-tiered').inputModalities).toEqual(['text', 'image'])
   })
 
   it('resolves exact-model metadata from the catalog', () => {
@@ -607,8 +609,15 @@ describe('models', () => {
     expect(resolved.reasoning).toBeDefined()
     expect(resolved.reasoning!.efforts.map((e) => String(e.id))).toEqual(['low', 'medium', 'high'])
     expect(String(resolved.reasoning!.defaultEffort)).toBe('medium')
+    expect(resolved.inputModalities).toEqual(['text', 'image'])
+
+    const tiered36 = resolveAgyModel('agy', 'gemini-3.6-flash-tiered')
+    expect(tiered36.reasoning).toBeDefined()
+    expect(tiered36.reasoning!.efforts.map((e) => String(e.id))).toEqual(['low', 'medium', 'high'])
+    expect(tiered36.inputModalities).toEqual(['text', 'image'])
+
     // legacy id-bound models and non-tiered discovered ids must not expose reasoning
-    for (const id of ['gemini-3.6-flash-high', 'gemini-3.6-flash-tiered', 'gemini-2.5-flash']) {
+    for (const id of ['gemini-3.6-flash-high', 'gemini-2.5-flash']) {
       expect(resolveAgyModel('agy', id).reasoning).toBeUndefined()
     }
   })


### PR DESCRIPTION
关联 Issue：Fixes #16

<details>
<summary>变更与验证</summary>

### 变更：

1. **`src/adapter/catalog.ts`**：
   - 补齐 `gemini-2.5-flash`、`gemini-2.5-flash-lite`、`gemini-2.5-flash-thinking`、`gemini-3.1-flash-lite` 的 `supportsVision: true`。
   - 登记 `gemini-3.6-flash-tiered` 为 `thinking: 'level', supportsVision: true`。
2. **`src/adapter/models.ts`**：
   - 在 `resolveAgyModel` 的 `isLevelThinkingModel` 分支补充漏传的 `inputModalities: inputModalitiesFor(meta)`。
3. **`tests/adapter.test.ts`**：
   - 补充对 level-thinking 模型与 Gemini 2.5 系列解析后 `inputModalities` 的单测断言。

### 验证：

- `tsc --noEmit`：通过
- `vitest run`：183/183 测试全部通过
- `tsdown`：构建成功

</details>