### PR TITLE
chore(release): 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-agy",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "packageManager": "pnpm@11.10.0",
   "description": "Google Antigravity (agy) OAuth auth + model access plugin for DeepSeek Harness: multi-account pool, 429 rotation, device fingerprinting, CLI and web login.",
   "type": "module",


### PR DESCRIPTION
Bump version 0.2.2 → 0.2.4 (0.2.3 already published as v0.2.3 tag on orphan e30e87b, local main was behind).

Includes #11 #12 #13 #17 merges. Tag v0.2.4 already pushed (f717ea9), this PR syncs package.json to main.

Closes #8 #9 #10 (already closed manually).