### PR TITLE
feat(adapter): dynamically resolve tiered thinking models and format display names

### DIFF
--- a/src/adapter/catalog.ts
+++ b/src/adapter/catalog.ts
@@ -21,6 +21,7 @@ export interface CatalogModel {
 }
 
 export const AGY_PUBLIC_MODELS: readonly CatalogModel[] = [
+  { id: 'gemini-3.8-flash-tiered', name: 'Gemini 3.8 Flash', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true, thinking: 'level' },
   { id: 'gemini-3.7-flash-tiered', name: 'Gemini 3.7 Flash', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true, thinking: 'level' },
   { id: 'gemini-3.6-flash-tiered', name: 'Gemini 3.6 Flash (Tiered)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true, thinking: 'level' },
   { id: 'gemini-3.6-flash-high', name: 'Gemini 3.6 Flash (High)', contextLength: 1048576, maxOutputTokens: 65536, supportsReasoning: true, supportsVision: true, toolCalling: true },
@@ -42,16 +43,43 @@ export const AGY_PUBLIC_MODELS: readonly CatalogModel[] = [
 
 const CATALOG_BY_ID = new Map(AGY_PUBLIC_MODELS.map((m) => [m.id, m]))
 
+/** Format dynamic tiered model id to display name (e.g. 'gemini-3.8-flash-tiered' -> 'Gemini 3.8 Flash'). */
+export function formatTieredModelName(modelId: string): string {
+  const base = modelId.replace(/-tiered$/, '')
+  return base
+    .split('-')
+    .map((part) => {
+      if (/^\d+(\.\d+)*$/.test(part)) return part
+      return part.charAt(0).toUpperCase() + part.slice(1)
+    })
+    .join(' ')
+}
+
 /** Tab-completion models are discoverable but not chat-callable. */
 export function isChatCallableModelId(modelId: string): boolean {
   return !modelId.startsWith('tab_')
 }
 
 export function catalogModel(modelId: string): CatalogModel | undefined {
-  return CATALOG_BY_ID.get(modelId)
+  const existing = CATALOG_BY_ID.get(modelId)
+  if (existing) return existing
+  if (typeof modelId === 'string' && modelId.endsWith('-tiered')) {
+    return {
+      id: modelId,
+      name: formatTieredModelName(modelId),
+      contextLength: 1048576,
+      maxOutputTokens: 65536,
+      supportsReasoning: true,
+      supportsVision: true,
+      toolCalling: true,
+      thinking: 'level',
+    }
+  }
+  return undefined
 }
 
 /** Level-thinking models: single id + selectable low/medium/high via thinkingLevel. */
 export function isLevelThinkingModel(modelId: string): boolean {
-  return catalogModel(modelId)?.thinking === 'level'
+  if (catalogModel(modelId)?.thinking === 'level') return true
+  return typeof modelId === 'string' && modelId.endsWith('-tiered')
 }

--- a/src/adapter/models.ts
+++ b/src/adapter/models.ts
@@ -84,10 +84,12 @@ export function mergeModelCatalog(dynamic: DiscoveredModels): LlmModelInfo[] {
   for (const [id, entry] of Object.entries(dynamic.models ?? {})) {
     if (!isChatCallableModelId(id)) continue
     const meta = catalogModel(id)
+    const rawDisplayName = entry.displayName && entry.displayName !== id ? entry.displayName : undefined
+    const displayName = rawDisplayName ?? meta?.name ?? entry.displayName ?? entry.modelName ?? id
     entries.push({
       provider: AGY_PROVIDER,
       id,
-      name: entry.displayName ?? meta?.name ?? entry.modelName ?? id,
+      name: displayName,
       inputModalities: inputModalitiesFor(meta),
       ...(meta ? { context: { contextWindow: meta.contextLength } } : {}),
     })

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -567,6 +567,8 @@ describe('models', () => {
         'gemini-3.6-flash-high': { displayName: 'Gemini 3.6 Flash (High)' },
         'tab_flash_lite_preview': { displayName: 'Tab Flash' },
         'some-new-model': { displayName: 'New' },
+        'gemini-3.8-flash-tiered': { displayName: 'gemini-3.8-flash-tiered' },
+        'gemini-3.9-flash-tiered': { displayName: 'gemini-3.9-flash-tiered' },
       },
     })
     const ids = merged.map((m) => m.id)
@@ -574,6 +576,10 @@ describe('models', () => {
     expect(ids).not.toContain('tab_flash_lite_preview')
     expect(merged.find((m) => m.id === 'gemini-3.6-flash-high')?.context?.contextWindow).toBe(1048576)
     expect(merged.find((m) => m.id === 'some-new-model')?.name).toBe('New')
+    // tiered model with raw id displayName is prettified from catalog / dynamic fallback
+    expect(merged.find((m) => m.id === 'gemini-3.8-flash-tiered')?.name).toBe('Gemini 3.8 Flash')
+    expect(merged.find((m) => m.id === 'gemini-3.9-flash-tiered')?.name).toBe('Gemini 3.9 Flash')
+    expect(merged.find((m) => m.id === 'gemini-3.9-flash-tiered')?.context?.contextWindow).toBe(1048576)
   })
 
   it('falls back to catalog when the endpoint fails', async () => {
@@ -604,8 +610,16 @@ describe('models', () => {
     expect(unknown.defaultMaxTokens).toBeUndefined()
   })
 
-  it('exposes reasoning efforts for tiered models', () => {
+  it('exposes reasoning efforts for tiered models (both catalog and dynamic)', () => {
+    const resolved38 = resolveAgyModel('agy', 'gemini-3.8-flash-tiered')
+    expect(resolved38.name).toBe('Gemini 3.8 Flash')
+    expect(resolved38.reasoning).toBeDefined()
+    expect(resolved38.reasoning!.efforts.map((e) => String(e.id))).toEqual(['low', 'medium', 'high'])
+    expect(String(resolved38.reasoning!.defaultEffort)).toBe('medium')
+    expect(resolved38.inputModalities).toEqual(['text', 'image'])
+
     const resolved = resolveAgyModel('agy', 'gemini-3.7-flash-tiered')
+    expect(resolved.name).toBe('Gemini 3.7 Flash')
     expect(resolved.reasoning).toBeDefined()
     expect(resolved.reasoning!.efforts.map((e) => String(e.id))).toEqual(['low', 'medium', 'high'])
     expect(String(resolved.reasoning!.defaultEffort)).toBe('medium')
@@ -616,27 +630,40 @@ describe('models', () => {
     expect(tiered36.reasoning!.efforts.map((e) => String(e.id))).toEqual(['low', 'medium', 'high'])
     expect(tiered36.inputModalities).toEqual(['text', 'image'])
 
+    // dynamically discovered uncataloged tiered model
+    const dynamicTiered = resolveAgyModel('agy', 'gemini-3.9-flash-tiered')
+    expect(dynamicTiered.name).toBe('Gemini 3.9 Flash')
+    expect(dynamicTiered.reasoning).toBeDefined()
+    expect(dynamicTiered.reasoning!.efforts.map((e) => String(e.id))).toEqual(['low', 'medium', 'high'])
+    expect(dynamicTiered.context?.contextWindow).toBe(1048576)
+    expect(dynamicTiered.defaultMaxTokens).toBe(65536)
+    expect(dynamicTiered.inputModalities).toEqual(['text', 'image'])
+
     // legacy id-bound models and non-tiered discovered ids must not expose reasoning
-    for (const id of ['gemini-3.6-flash-high', 'gemini-2.5-flash']) {
+    for (const id of ['gemini-3.6-flash-high', 'gemini-2.5-flash', 'brand-new-model']) {
       expect(resolveAgyModel('agy', id).reasoning).toBeUndefined()
     }
   })
 
   it('maps reasoningEffort to thinkingConfig for tiered models only', () => {
-    const low = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered', reasoningEffort: 'low' as any }), {})
+    const low = toAgyRequestBody(generateOptions({ model: 'gemini-3.8-flash-tiered', reasoningEffort: 'low' as any }), {})
     expect(low.request.generationConfig).toMatchObject({ thinkingConfig: { thinkingLevel: 'low', includeThoughts: true } })
-    const medium = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered', reasoningEffort: 'medium' as any }), {})
+    const medium = toAgyRequestBody(generateOptions({ model: 'gemini-3.8-flash-tiered', reasoningEffort: 'medium' as any }), {})
     expect(medium.request.generationConfig).toMatchObject({ thinkingConfig: { thinkingLevel: 'medium', includeThoughts: true } })
-    const high = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered', reasoningEffort: 'high' as any }), {})
+    const high = toAgyRequestBody(generateOptions({ model: 'gemini-3.8-flash-tiered', reasoningEffort: 'high' as any }), {})
     expect(high.request.generationConfig).toMatchObject({ thinkingConfig: { thinkingLevel: 'high', includeThoughts: true } })
 
-    const noEffort = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered' }), {})
+    // dynamic uncataloged tiered model also sends thinkingConfig
+    const dynamicHigh = toAgyRequestBody(generateOptions({ model: 'gemini-3.9-flash-tiered', reasoningEffort: 'high' as any }), {})
+    expect(dynamicHigh.request.generationConfig).toMatchObject({ thinkingConfig: { thinkingLevel: 'high', includeThoughts: true } })
+
+    const noEffort = toAgyRequestBody(generateOptions({ model: 'gemini-3.8-flash-tiered' }), {})
     expect(noEffort.request.generationConfig?.thinkingConfig).toBeUndefined()
 
     const fixedModel = toAgyRequestBody(generateOptions({ model: 'gemini-3.6-flash-high', reasoningEffort: 'high' as any }), {})
     expect(fixedModel.request.generationConfig?.thinkingConfig).toBeUndefined()
 
-    const invalid = toAgyRequestBody(generateOptions({ model: 'gemini-3.7-flash-tiered', reasoningEffort: 'ultra' as any }), {})
+    const invalid = toAgyRequestBody(generateOptions({ model: 'gemini-3.8-flash-tiered', reasoningEffort: 'ultra' as any }), {})
     expect(invalid.request.generationConfig?.thinkingConfig).toBeUndefined()
   })
 })

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -3,6 +3,7 @@ import type { GenerateOptions, Message } from '@deepseek-ai/dsh-llm'
 import { AGY_SCHEMA_ALLOWLIST, toAgyRequestBody } from '../src/adapter/translate.ts'
 import { parseAgySse, parseSseDataLine } from '../src/adapter/parse.ts'
 import { catalogModelList, fetchAvailableModels, listAgyModels, mergeModelCatalog, resolveAgyModel } from '../src/adapter/models.ts'
+import { formatTieredModelName } from '../src/adapter/catalog.ts'
 import { AgyAdapter } from '../src/adapter/adapter.ts'
 import type { AgyAccountSession } from '../src/adapter/adapter.ts'
 import { AgyAuthError, AgyPoolBlockedError } from '../src/types.ts'
@@ -561,6 +562,12 @@ describe('parseAgySse', () => {
 })
 
 describe('models', () => {
+  it('formats tiered model ids into human-readable display names', () => {
+    expect(formatTieredModelName('gemini-3.8-flash-tiered')).toBe('Gemini 3.8 Flash')
+    expect(formatTieredModelName('gemini-3.9-flash-tiered')).toBe('Gemini 3.9 Flash')
+    expect(formatTieredModelName('gemini-4.0-pro-tiered')).toBe('Gemini 4.0 Pro')
+  })
+
   it('merges dynamic ids with catalog metadata and filters tab models', () => {
     const merged = mergeModelCatalog({
       models: {


### PR DESCRIPTION
## Summary

- **Dynamic Tiered Model Resolution**: Dynamically infers level-thinking capabilities for models ending in `-tiered` (e.g. `gemini-3.8-flash-tiered` and future tiered releases), so newly released tiered models automatically support reasoning effort controls (`low` / `medium` / `high`), vision input, and 1M context window without requiring immediate manual catalog updates.
- **Display Name Formatting**: Adds `formatTieredModelName()` to clean up raw dynamic model IDs (e.g. `gemini-3.8-flash-tiered` -> `Gemini 3.8 Flash`) in `mergeModelCatalog` when upstream `displayName` defaults to the raw model ID.
- **Catalog Update**: Explicitly adds `gemini-3.8-flash-tiered` to the static `AGY_PUBLIC_MODELS` fallback list.
- **Tests**: Expanded unit tests in `tests/adapter.test.ts` to verify both catalog-registered and dynamically discovered tiered models.

## Verification

- `pnpm test`: 183/183 tests passed.
- `pnpm run typecheck`: Passed with zero TypeScript errors.
- `pnpm run build` & `npm pack --dry-run`: Clean bundle and package build.
- Live tested against DeepSeek Harness: `gemini-3.8-flash-tiered` exposes `low / medium / high` reasoning effort controls and cleanly emits `generationConfig.thinkingConfig`.